### PR TITLE
fix(home): Improve hero scroll affordance positioning

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -48,11 +48,12 @@
 /* ===== Hero ===== */
 
 .hero {
-  min-height: 100vh;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   padding: var(--section-padding-x);
+  position: relative;
 }
 
 .hero-inner {
@@ -97,7 +98,7 @@
 
 .hero-scroll {
   position: absolute;
-  bottom: 2.5rem;
+  bottom: clamp(1.5rem, 3vw, 2.5rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;


### PR DESCRIPTION
Use 100svh to account for mobile browser chrome, add position relative to hero so the scroll indicator anchors correctly, and use clamp() for responsive bottom spacing.