### PR TITLE
feat(contact): Add sequential hover highlight on scroll into view

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -554,6 +554,22 @@ const currentYear = new Date().getFullYear();
           );
         }, { amount: 0.05 });
       });
+
+      // Contact links: sequential hover highlight after fade-in
+      let contactHighlighted = false;
+      inView('#contact', () => {
+        if (contactHighlighted) return;
+        contactHighlighted = true;
+        const links = document.querySelectorAll('.contact-link');
+        const FADE_IN = 500;
+        const ON = 400;
+        const GAP = 150;
+        links.forEach((link, i) => {
+          const start = FADE_IN + i * (ON + GAP);
+          setTimeout(() => link.classList.add('is-highlighted'), start);
+          setTimeout(() => link.classList.remove('is-highlighted'), start + ON);
+        });
+      }, { amount: 0.05 });
     } else {
       // Reduced motion: just show everything
       document.querySelectorAll('.motion-fade, .motion-letter, .motion-stagger').forEach((el) => {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -613,11 +613,13 @@
   transition: width 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.contact-link:hover {
+.contact-link:hover,
+.contact-link.is-highlighted {
   color: var(--color-accent);
 }
 
-.contact-link:hover::after {
+.contact-link:hover::after,
+.contact-link.is-highlighted::after {
   width: 100%;
 }
 


### PR DESCRIPTION
When the contact section enters the viewport, Email, LinkedIn, and Upwork links each briefly highlight in order — reusing the existing hover style (accent color + underline) — to draw attention to the call-to-action.