### PR TITLE
fix(css): remove default highlight on Other Work rows

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -261,7 +261,7 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-.compact-row::before {
+.compact-row:hover::before {
   width: 2px;
 }
 


### PR DESCRIPTION
The .compact-row::before selector was unconditionally setting width: 2px, overriding the .hover-row::before default of width: 0. This caused the accent bar to always be visible instead of only appearing on hover.