### PR TITLE
polish(ui): accessibility, design tokens, and 404 page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -35,7 +35,7 @@ const schemaOrgWebPage = {
     name: 'Ralph Jonas Mungcal'
   },
   datePublished: '2019-01-17',
-  dateModified: '2022-02-27',
+  dateModified: new Date().toISOString().split('T')[0],
   image: {
     '@type': 'ImageObject',
     url: 'https://ralphjonas.com/logo.png'

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,8 +5,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="404 | Ralph Jonas Mungcal">
   <main style="min-height:100vh;display:grid;place-items:center;padding:2rem;text-align:center;">
     <div>
-      <h1 style="font-family:'Cantata One', Georgia, serif;font-size:3rem;letter-spacing:0.05em;margin:0 0 1rem;">404</h1>
-      <p style="font-size:1.25rem;color:#b8c2cc;margin:0;">Page not found.</p>
+      <h1 style="font-family:var(--font-heading);font-size:clamp(3rem, 10vw, 6rem);font-weight:700;letter-spacing:-0.04em;margin:0 0 1rem;">404</h1>
+      <p style="font-family:var(--font-body);font-size:1.125rem;color:var(--color-text-muted);margin:0 0 2rem;">Page not found.</p>
+      <a href="/" style="font-family:var(--font-heading);font-size:0.875rem;font-weight:500;color:var(--color-text-muted);letter-spacing:0.05em;text-decoration:none;border-bottom:1px solid var(--color-border);padding-bottom:0.25rem;transition:color 0.3s ease,border-color 0.3s ease;"
+        onmouseover="this.style.color='var(--color-accent)';this.style.borderColor='var(--color-accent)'"
+        onmouseout="this.style.color='var(--color-text-muted)';this.style.borderColor='var(--color-border)'"
+      >Back to home</a>
     </div>
   </main>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ const MAX_POSTS = 5;
 interface BlogPost {
   title: string;
   date: string;
+  datetime: string;
   url: string;
 }
 
@@ -34,8 +35,9 @@ try {
 
     const dateObj = new Date(published);
     const formattedDate = `${dateObj.getFullYear()}.${String(dateObj.getMonth() + 1).padStart(2, '0')}`;
+    const isoDate = dateObj.toISOString().split('T')[0];
 
-    return { title, date: formattedDate, url: link };
+    return { title, date: formattedDate, datetime: isoDate, url: link };
   });
 } catch (e) {
   // Build won't break if Bear Blog is down — section renders empty gracefully
@@ -80,7 +82,7 @@ try {
       <div class="section-inner">
         <span class="section-number motion-fade">01.</span>
         <h2 class="section-heading motion-fade">About<span class="dot-target" aria-hidden="true">.</span></h2>
-        <hr class="section-rule" />
+        <hr class="section-rule" role="presentation" />
 
         <div class="about-grid">
           <div class="about-col-left">
@@ -133,9 +135,9 @@ try {
       <div class="section-inner">
         <span class="section-number motion-fade">02.</span>
         <h2 class="section-heading motion-fade">Projects<span class="dot-target" aria-hidden="true">.</span></h2>
-        <hr class="section-rule" />
+        <hr class="section-rule" role="presentation" />
 
-        <ul class="project-list">
+        <ul class="project-list" role="list">
           <li class="project-row hover-row motion-stagger">
             <span class="project-name">Flight Rewards Search Platform</span>
             <span class="project-tech">Node.js · TypeScript · PostgreSQL · GCP</span>
@@ -165,7 +167,7 @@ try {
 
         <h3 class="other-heading motion-fade">Other Work</h3>
 
-        <ul class="project-list">
+        <ul class="project-list" role="list">
           <li class="compact-row hover-row motion-stagger">
             <span class="compact-name">Airline Route Mapping Service</span>
             <span class="compact-tech">TypeScript · Node.js</span>
@@ -211,9 +213,9 @@ try {
       <div class="section-inner">
         <span class="section-number motion-fade">03.</span>
         <h2 class="section-heading motion-fade">Side Projects<span class="dot-target" aria-hidden="true">.</span></h2>
-        <hr class="section-rule" />
+        <hr class="section-rule" role="presentation" />
 
-        <ul class="side-project-list">
+        <ul class="side-project-list" role="list">
           <li>
             <a href="https://subconsciousapp.co" class="side-project-row hover-row motion-stagger" target="_blank" rel="noopener noreferrer">
               <div class="side-project-info">
@@ -250,14 +252,14 @@ try {
       <div class="section-inner">
         <span class="section-number motion-fade">04.</span>
         <h2 class="section-heading motion-fade">Writing<span class="dot-target" aria-hidden="true">.</span></h2>
-        <hr class="section-rule" />
+        <hr class="section-rule" role="presentation" />
 
-        <ul class="writing-list">
+        <ul class="writing-list" role="list">
           {blogPosts.length > 0 ? (
             blogPosts.map((post) => (
               <li>
                 <a href={post.url} class="writing-row hover-row motion-stagger" target="_blank" rel="noopener noreferrer">
-                  <time class="writing-date">{post.date}</time>
+                  <time class="writing-date" datetime={post.datetime}>{post.date}</time>
                   <span class="writing-title">{post.title}</span>
                   <span class="writing-arrow" aria-hidden="true">&rarr;</span>
                 </a>
@@ -283,7 +285,7 @@ try {
         <h2 class="contact-cta motion-fade">
           Let's work<br />together<span class="dot-target" aria-hidden="true">&#8203;</span><span class="contact-period">.</span>
         </h2>
-        <hr class="section-rule" />
+        <hr class="section-rule" role="presentation" />
 
         <div class="contact-links">
           <a href="mailto:ralphmungcal09@gmail.com" class="contact-link motion-stagger">Email</a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,8 @@
   --color-accent: #ff3333;
   --color-border: #1a1a1a;
   --color-surface: #111111;
+  --color-accent-subtle: rgba(255, 51, 51, 0.08);
+  --color-text-faint: rgba(255, 255, 255, 0.2);
 
   --font-heading: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -445,7 +445,7 @@
 
 .about-stack-item:hover {
   border-color: var(--color-accent);
-  background: rgba(255, 51, 51, 0.08);
+  background: var(--color-accent-subtle);
 }
 
 /* ===== Writing (Blog) ===== */
@@ -500,18 +500,27 @@
   color: var(--color-text-muted);
   transition: transform 0.3s ease, color 0.3s ease;
   margin-left: auto;
-  display: none;
+  flex-shrink: 0;
 }
 
-@media (min-width: 768px) {
+@media (max-width: 767px) {
   .writing-arrow {
-    display: block;
+    font-size: 1rem;
+    align-self: flex-end;
   }
 }
 
 .writing-row:hover .writing-arrow {
   transform: translateX(6px);
   color: var(--color-accent);
+}
+
+.writing-empty {
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: clamp(1rem, 2vw, 1.25rem) 0;
 }
 
 .writing-view-all {
@@ -652,7 +661,7 @@
   padding: clamp(2rem, 4vw, 3rem) var(--section-padding-x);
   font-family: var(--font-body);
   font-size: 0.8125rem;
-  color: rgba(255, 255, 255, 0.2);
+  color: var(--color-text-faint);
   letter-spacing: 0.03em;
   max-width: var(--max-width);
   margin: 0 auto;
@@ -670,7 +679,7 @@
   opacity: 0;
   pointer-events: none;
   will-change: transform, opacity;
-  box-shadow: 0 0 12px rgba(255, 51, 51, 0.4);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--color-accent) 40%, transparent);
   transition: opacity 0.4s ease;
 }
 
@@ -684,6 +693,39 @@
 
 .scroll-dot--settled {
   transition: opacity 0.3s ease;
+}
+
+/* ===== Focus Styles ===== */
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.hover-row:focus-visible {
+  padding-left: 1.25rem;
+}
+
+.hover-row:focus-visible::before {
+  width: 3px;
+}
+
+.compact-row:focus-visible::before {
+  width: 2px;
+}
+
+.focus-item:focus-visible,
+.about-stack-item:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.contact-link:focus-visible {
+  color: var(--color-accent);
+}
+
+.contact-link:focus-visible::after {
+  width: 100%;
 }
 
 /* ===== Motion Initial States ===== */


### PR DESCRIPTION
## Summary

- Add `:focus-visible` keyboard navigation styles for all interactive elements (hover rows, stack items, contact links)
- Add ARIA `role="presentation"` on decorative `<hr>` elements, `role="list"` on `<ul>` lists, and `datetime` attributes on `<time>` elements for screen reader compatibility
- Extract hardcoded `rgba()` color values into CSS custom properties (`--color-accent-subtle`, `--color-text-faint`) and use `color-mix()` for the scroll dot shadow
- Redesign the 404 page to use design system tokens with a "Back to home" link
- Fix writing section arrow to always render (was `display:none` on mobile) with responsive sizing
- Make schema.org `dateModified` dynamic instead of hardcoded

## Test plan

- [ ] Tab through the entire page and verify focus rings appear on all interactive elements
- [ ] Check 404 page at `/nonexistent-path` — should show styled heading, message, and back link
- [ ] Verify writing arrows show on both mobile and desktop viewports
- [ ] Validate structured data with Google Rich Results Test
- [ ] Run Lighthouse accessibility audit — score should be 95+

🤖 Generated with [Claude Code](https://claude.com/claude-code)