### PR TITLE
feat(ui): Terminal brutalism redesign, light-only theme

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -67,7 +67,7 @@ const breadcrumb = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
     <title>{title}</title>
 
     <link rel="apple-touch-icon" href="/favicons/apple-touch-icon.png" />
@@ -95,7 +95,7 @@ const breadcrumb = {
     <meta name="twitter:image" content="https://ralphjonas.com/logo.png" />
     <meta name="twitter:image:alt" content={description} />
 
-    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="theme-color" content="#fdfbf0" />
     <link rel="manifest" href="/manifest.webmanifest" crossorigin="anonymous" />
 
     <script is:inline type="application/ld+json" set:html={JSON.stringify(schemaOrgWebPage)}></script>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,12 +2,18 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="404 | Ralph Jonas Mungcal">
+<BaseLayout title="404 | ralph jonas mungcal">
   <main class="not-found">
     <div class="not-found__inner">
+      <div class="not-found__shell" aria-hidden="true">
+        <span class="not-found__prompt">$</span>
+        <span class="not-found__cmd">cd</span>
+        <span class="not-found__arg" id="nf-path">/requested/path</span>
+      </div>
+      <p class="not-found__error">bash: cd: <span id="nf-path-2">requested path</span>: no such file or directory</p>
       <h1 class="not-found__code">404</h1>
-      <p class="not-found__message">Page not found.</p>
-      <a href="/" class="not-found__link">Back to home</a>
+      <p class="not-found__message">the page you were looking for has been unlinked, moved, or never existed.</p>
+      <a href="/" class="not-found__link">$ cd ~/</a>
     </div>
   </main>
 
@@ -17,47 +23,87 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       display: grid;
       place-items: center;
       padding: 2rem;
-      text-align: center;
+    }
+
+    .not-found__inner {
+      width: 100%;
+      max-width: 560px;
+      border: var(--border-w) solid var(--color-border);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-hard-lg);
+      padding: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    .not-found__shell {
+      font-size: 0.85rem;
+      color: var(--color-ink-soft);
+      margin-bottom: 0.75rem;
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+
+    .not-found__prompt {
+      color: var(--color-accent);
+      font-weight: 700;
+    }
+
+    .not-found__error {
+      font-size: 0.8rem;
+      color: var(--color-ink-muted);
+      margin-bottom: 1.25rem;
+      word-break: break-word;
     }
 
     .not-found__code {
-      font-family: var(--font-heading);
-      font-size: clamp(3rem, 10vw, 6rem);
-      font-weight: 700;
+      font-family: var(--font-mono);
+      font-size: clamp(3.5rem, 11vw, 6rem);
+      font-weight: 800;
       letter-spacing: -0.04em;
-      margin: 0 0 1rem;
+      margin: 0 0 0.75rem;
+      color: var(--color-accent);
+      line-height: 1;
     }
 
     .not-found__message {
-      font-family: var(--font-body);
-      font-size: 1.125rem;
-      color: var(--color-text-muted);
-      margin: 0 0 2rem;
+      font-size: 0.9rem;
+      color: var(--color-ink-soft);
+      line-height: 1.55;
+      margin-bottom: 1.5rem;
+      max-width: 50ch;
     }
 
     .not-found__link {
-      font-family: var(--font-heading);
-      font-size: 0.875rem;
-      font-weight: 500;
-      color: var(--color-text-muted);
-      letter-spacing: 0.05em;
+      display: inline-block;
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: var(--color-ink);
       text-decoration: none;
-      border-bottom: 1px solid var(--color-border);
-      padding-bottom: 0.25rem;
-      transition: color 0.3s ease, border-color 0.3s ease;
+      padding: 0.5rem 0.85rem;
+      border: var(--border-w) solid var(--color-border);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-hard-sm);
+      transition: transform 0.12s ease, background 0.12s ease;
     }
 
     .not-found__link:hover,
     .not-found__link:focus-visible {
-      color: var(--color-accent);
-      border-color: var(--color-accent);
+      transform: translate(-2px, -2px);
+      background: var(--color-accent);
+      outline: none;
     }
   </style>
 
   <script>
+    const path = window.location.pathname;
+    const target = document.getElementById('nf-path');
+    const target2 = document.getElementById('nf-path-2');
+    if (target) target.textContent = path;
+    if (target2) target2.textContent = path;
+
     const ph = (window as any).posthog;
     if (ph) {
-      ph.capture('404_hit', { path: window.location.pathname });
+      ph.capture('404_hit', { path });
     }
   </script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,55 +8,90 @@ const currentYear = new Date().getFullYear();
 const BLOG_FEED_URL = 'https://ralphdev.bearblog.dev/feed/';
 const MAX_POSTS = 5;
 const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
+
+const HERO_SUBTITLE = 'full-stack developer & ai integration specialist. i build scalable, practical software — backend architecture, cloud infra, dev tooling, ai-powered workflows.';
 ---
 
 <BaseLayout>
   <div class="scroll-dot" aria-hidden="true"></div>
 
   <main class="portfolio-page">
+    <!-- Shell Bar -->
+    <div class="shell-bar" role="banner">
+      <div class="shell-bar-dots" aria-hidden="true">
+        <span class="shell-bar-dot shell-bar-dot--live"></span>
+        <span class="shell-bar-dot"></span>
+        <span class="shell-bar-dot"></span>
+      </div>
+      <span class="shell-bar-path">ralph@jonas:~ — portfolio.sh</span>
+      <span class="shell-bar-hint">
+        press <kbd>g</kbd> then <kbd>a</kbd>/<kbd>p</kbd>/<kbd>s</kbd>/<kbd>w</kbd>/<kbd>c</kbd>
+      </span>
+    </div>
+
     <!-- Hero -->
     <section class="hero" id="hero">
       <div class="hero-inner">
+        <div class="hero-whoami" aria-hidden="true">
+          <span class="hero-whoami-prompt">$</span>
+          <span>whoami</span>
+          <span style="color: var(--color-ink-muted);">--verbose</span>
+        </div>
+
         <h1 class="hero-name" aria-label="Ralph Jonas">
           <span class="hero-name-line">
-            {'RALPH'.split('').map(letter => (
+            {'ralph'.split('').map(letter => (
               <span class="hero-name-letter motion-letter">{letter}</span>
             ))}
           </span>
           <span class="hero-name-line">
-            {'JONAS'.split('').map(letter => (
+            {'jonas'.split('').map(letter => (
               <span class="hero-name-letter motion-letter">{letter}</span>
             ))}
-            <span class="hero-name-letter motion-letter hero-period">.</span>
+            <span class="hero-name-letter motion-letter hero-period">_</span>
           </span>
         </h1>
-        <p class="hero-subtitle motion-fade">
-          Full-Stack Developer &amp; AI Integration Specialist building scalable, practical software.
-        </p>
-      </div>
 
-      <div class="hero-scroll motion-fade" aria-hidden="true">
-        <span class="hero-scroll-text">Scroll</span>
-        <span class="hero-scroll-arrow">&#8595;</span>
-        <span class="hero-scroll-line"></span>
+        <p class="hero-subtitle motion-fade" data-typewriter={HERO_SUBTITLE}>
+          <span class="hero-subtitle-text">{HERO_SUBTITLE}</span>
+          <span class="hero-cursor" aria-hidden="true"></span>
+        </p>
+
+        <div class="hero-tags motion-fade" aria-hidden="true">
+          <span class="hero-tag">#typescript</span>
+          <span class="hero-tag">#node</span>
+          <span class="hero-tag">#gcp</span>
+          <span class="hero-tag">#ai</span>
+          <span class="hero-tag">#linux</span>
+        </div>
+
+        <div class="hero-scroll motion-fade">
+          <span class="hero-scroll-text">scroll</span>
+          <span class="hero-scroll-arrow">&#8595;</span>
+        </div>
       </div>
     </section>
 
     <!-- 01. About -->
     <section class="section" id="about">
       <div class="section-inner">
-        <span class="section-number motion-fade">01.</span>
-        <h2 class="section-heading motion-fade">About<span class="dot-target" aria-hidden="true">.</span></h2>
+        <div class="section-header">
+          <span class="section-prompt">$</span>
+          <span class="section-cmd">cat about.md</span>
+          <span class="section-cmd-flag">--format=plain</span>
+          <span class="section-number">01<span class="dot-target" aria-hidden="true">.</span></span>
+        </div>
+        <h2 class="section-heading" style="position:absolute;left:-9999px;">about</h2>
         <hr class="section-rule" role="presentation" />
 
         <div class="about-grid">
           <div class="about-col-left">
-            <span class="about-name motion-fade" aria-label="Ralph Jonas Mungcal">Ralph Jonas</span>
+            <span class="about-name motion-fade" aria-label="Ralph Jonas Mungcal">ralph jonas</span>
             <p class="about-bio motion-fade">
-              Full-stack developer and AI integration specialist based in the Philippines. I build products end-to-end — from backend architecture and cloud infrastructure to developer tooling and AI-powered workflows.
+              full-stack developer and ai integration specialist based in the philippines. i build products end-to-end — from backend architecture and cloud infra to dev tooling and ai-powered workflows.
             </p>
             <p class="about-bio motion-fade">
-              I focus on writing clean, maintainable systems that solve real problems. Whether it's orchestrating payments across multiple gateways, building data aggregation pipelines, or setting up self-hosted infrastructure — I care about getting the details right.
+              i focus on writing clean, maintainable systems that solve real problems. whether it's orchestrating payments across multiple gateways, building data aggregation pipelines, or self-hosting infra — details matter.
             </p>
           </div>
 
@@ -64,30 +99,30 @@ const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
             <div class="about-stats">
               <div class="about-stat motion-stagger">
                 <span class="about-stat-number" data-count={currentYear - 2018}>0+</span>
-                <span class="about-stat-label">Years Building Software</span>
+                <span class="about-stat-label">years shipping</span>
               </div>
               <div class="about-stat motion-stagger">
                 <span class="about-stat-number" data-count="10">0+</span>
-                <span class="about-stat-label">Projects Shipped</span>
+                <span class="about-stat-label">projects shipped</span>
               </div>
             </div>
 
             <div class="focus-list">
-              <span class="focus-item motion-stagger">Backend Architecture</span>
-              <span class="focus-item motion-stagger">AI Integration</span>
-              <span class="focus-item motion-stagger">Cloud Infrastructure</span>
-              <span class="focus-item motion-stagger">Developer Tooling</span>
+              <span class="focus-item motion-stagger">backend-arch</span>
+              <span class="focus-item motion-stagger">ai-integration</span>
+              <span class="focus-item motion-stagger">cloud-infra</span>
+              <span class="focus-item motion-stagger">dev-tooling</span>
             </div>
 
             <div class="about-stack">
-              <span class="about-stack-label motion-fade">Daily drivers</span>
+              <span class="about-stack-label motion-fade">daily-drivers</span>
               <div class="about-stack-items">
-                <span class="about-stack-item motion-stagger">TypeScript</span>
-                <span class="about-stack-item motion-stagger">Node.js</span>
-                <span class="about-stack-item motion-stagger">GCP</span>
-                <span class="about-stack-item motion-stagger">Docker</span>
-                <span class="about-stack-item motion-stagger">PostgreSQL</span>
-                <span class="about-stack-item motion-stagger">Linux</span>
+                <span class="about-stack-item motion-stagger">typescript</span>
+                <span class="about-stack-item motion-stagger">node.js</span>
+                <span class="about-stack-item motion-stagger">gcp</span>
+                <span class="about-stack-item motion-stagger">docker</span>
+                <span class="about-stack-item motion-stagger">postgres</span>
+                <span class="about-stack-item motion-stagger">linux</span>
               </div>
             </div>
           </div>
@@ -98,76 +133,81 @@ const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
     <!-- 02. Projects -->
     <section class="section" id="projects">
       <div class="section-inner">
-        <span class="section-number motion-fade">02.</span>
-        <h2 class="section-heading motion-fade">Projects<span class="dot-target" aria-hidden="true">.</span></h2>
+        <div class="section-header">
+          <span class="section-prompt">$</span>
+          <span class="section-cmd">ls ./projects/</span>
+          <span class="section-cmd-flag">-la</span>
+          <span class="section-number">02<span class="dot-target" aria-hidden="true">.</span></span>
+        </div>
+        <h2 class="section-heading" style="position:absolute;left:-9999px;">projects</h2>
         <hr class="section-rule" role="presentation" />
 
         <ul class="project-list" role="list">
-          <li class="project-row hover-row motion-stagger">
-            <span class="project-name">Flight Rewards Search Platform</span>
-            <span class="project-tech">Node.js · TypeScript · PostgreSQL · GCP</span>
-            <p class="project-desc">Technical lead for a UK-based SaaS platform that helps users find and compare reward flight availability across major airlines.</p>
+          <li class="project-row motion-stagger">
+            <span class="project-name">flight-rewards-search</span>
+            <span class="project-tech">node · ts · postgres · gcp</span>
+            <p class="project-desc">technical lead for a uk-based saas — reward flight availability search across major airlines.</p>
           </li>
-          <li class="project-row hover-row motion-stagger">
-            <span class="project-name">Billing &amp; Payment Platform</span>
-            <span class="project-tech">Node.js · TypeScript · GCP · Event-Driven</span>
-            <p class="project-desc">Multi-gateway payment orchestration platform with unified subscription billing, dunning management, and smart retry logic.</p>
+          <li class="project-row motion-stagger">
+            <span class="project-name">billing-payment-platform</span>
+            <span class="project-tech">node · ts · gcp · event-driven</span>
+            <p class="project-desc">multi-gateway payment orchestration with unified subscription billing, dunning, smart retry.</p>
           </li>
-          <li class="project-row hover-row motion-stagger">
-            <span class="project-name">Airline Data Aggregation Bots</span>
-            <span class="project-tech">TypeScript · Puppeteer · BullMQ</span>
-            <p class="project-desc">Automated scrapers collecting flight availability data from multiple airline sources on scheduled intervals.</p>
+          <li class="project-row motion-stagger">
+            <span class="project-name">airline-data-bots</span>
+            <span class="project-tech">ts · puppeteer · bullmq</span>
+            <p class="project-desc">automated scrapers collecting flight availability data from multiple airline sources on schedule.</p>
           </li>
-          <li class="project-row hover-row motion-stagger">
-            <span class="project-name">Remote MCP Server</span>
-            <span class="project-tech">TypeScript · Node.js · Docker</span>
-            <p class="project-desc">Model Context Protocol server accessible via URL, enabling AI assistants to interact with custom tools through SSE transport.</p>
+          <li class="project-row motion-stagger">
+            <span class="project-name">remote-mcp-server</span>
+            <span class="project-tech">ts · node · docker</span>
+            <p class="project-desc">model context protocol server over url — ai assistants hit custom tools via sse transport.</p>
           </li>
-          <li class="project-row hover-row motion-stagger">
-            <span class="project-name">Home Infrastructure Lab</span>
-            <span class="project-tech">Docker · Linux · TrueNAS · Tailscale</span>
-            <p class="project-desc">Multi-node self-hosted services ecosystem including NAS, media streaming, workflow automation, and monitoring dashboards.</p>
+          <li class="project-row motion-stagger">
+            <span class="project-name">home-infra-lab</span>
+            <span class="project-tech">docker · linux · truenas · tailscale</span>
+            <p class="project-desc">multi-node self-hosted services — nas, media, workflow automation, monitoring dashboards.</p>
           </li>
         </ul>
 
-        <h3 class="other-heading motion-fade">Other Work</h3>
+        <h3 class="other-heading motion-fade">other-work</h3>
 
-        <ul class="project-list" role="list">
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Airline Route Mapping Service</span>
-            <span class="compact-tech">TypeScript · Node.js</span>
+        <ul class="project-list" role="list" style="grid-template-columns: 1fr;">
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">airline-route-mapping</span>
+            <span class="compact-tech">ts · node</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Loyalty Points Transfer Engine</span>
-            <span class="compact-tech">Node.js · TypeScript · React</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">loyalty-points-transfer</span>
+            <span class="compact-tech">node · ts · react</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Subscription Service Architecture</span>
-            <span class="compact-tech">Node.js · GCP · Pub/Sub</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">subscription-architecture</span>
+            <span class="compact-tech">node · gcp · pub/sub</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">AI Development Workflow Standards</span>
-            <span class="compact-tech">Claude · OpenAI</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">ai-dev-workflow-standards</span>
+            <span class="compact-tech">claude · openai</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Local AI Inference Server</span>
-            <span class="compact-tech">Linux · AI/ML Inference</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">local-ai-inference-server</span>
+            <span class="compact-tech">linux · ml-inference</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Accident Detection Device</span>
-            <span class="compact-tech">Raspberry Pi · Python</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">accident-detection-device</span>
+            <span class="compact-tech">rpi · python</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Accident Detection Control Panel</span>
-            <span class="compact-tech">MongoDB · Express · Angular · Node.js</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">accident-detection-panel</span>
+            <span class="compact-tech">mongo · express · angular · node</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Audit &amp; Report Generator</span>
-            <span class="compact-tech">Angular · Node.js · SQL · AWS</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">audit-report-generator</span>
+            <span class="compact-tech">angular · node · sql · aws</span>
           </li>
-          <li class="compact-row hover-row motion-stagger">
-            <span class="compact-name">Freelance Projects</span>
-            <span class="compact-tech">Upwork</span>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">freelance-projects</span>
+            <span class="compact-tech">upwork</span>
           </li>
         </ul>
       </div>
@@ -176,34 +216,39 @@ const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
     <!-- 03. Side Projects -->
     <section class="section" id="side-projects">
       <div class="section-inner">
-        <span class="section-number motion-fade">03.</span>
-        <h2 class="section-heading motion-fade">Side Projects<span class="dot-target" aria-hidden="true">.</span></h2>
+        <div class="section-header">
+          <span class="section-prompt">$</span>
+          <span class="section-cmd">cd ~/side-projects/</span>
+          <span class="section-cmd-flag">&amp;&amp; ls</span>
+          <span class="section-number">03<span class="dot-target" aria-hidden="true">.</span></span>
+        </div>
+        <h2 class="section-heading" style="position:absolute;left:-9999px;">side projects</h2>
         <hr class="section-rule" role="presentation" />
 
         <ul class="side-project-list" role="list">
           <li>
-            <a href="https://subconsciousapp.co" class="side-project-row hover-row motion-stagger" target="_blank" rel="noopener noreferrer">
+            <a href="https://subconsciousapp.co" class="side-project-row motion-stagger" target="_blank" rel="noopener noreferrer">
               <div class="side-project-info">
-                <span class="side-project-name">Subconscious</span>
-                <p class="side-project-desc">Subscription tracking app — take control of your recurring expenses.</p>
+                <span class="side-project-name">subconscious</span>
+                <p class="side-project-desc">subscription tracking — take control of recurring expenses.</p>
               </div>
               <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
             </a>
           </li>
           <li>
-            <a href="https://spotthesynth.com" class="side-project-row hover-row motion-stagger" target="_blank" rel="noopener noreferrer">
+            <a href="https://spotthesynth.com" class="side-project-row motion-stagger" target="_blank" rel="noopener noreferrer">
               <div class="side-project-info">
-                <span class="side-project-name">Spot the Synth</span>
-                <p class="side-project-desc">Community-driven AI photo spotting and discussion.</p>
+                <span class="side-project-name">spot-the-synth</span>
+                <p class="side-project-desc">community-driven ai photo spotting and discussion.</p>
               </div>
               <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
             </a>
           </li>
           <li>
-            <a href="https://theleonfiles.com" class="side-project-row hover-row motion-stagger" target="_blank" rel="noopener noreferrer">
+            <a href="https://theleonfiles.com" class="side-project-row motion-stagger" target="_blank" rel="noopener noreferrer">
               <div class="side-project-info">
-                <span class="side-project-name">The Leon Files</span>
-                <p class="side-project-desc">A fan site dedicated to Leon Kennedy of Resident Evil.</p>
+                <span class="side-project-name">the-leon-files</span>
+                <p class="side-project-desc">fan site — leon kennedy, resident evil.</p>
               </div>
               <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
             </a>
@@ -215,15 +260,20 @@ const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
     <!-- 04. Writing -->
     <section class="section" id="writing">
       <div class="section-inner">
-        <span class="section-number motion-fade">04.</span>
-        <h2 class="section-heading motion-fade">Writing<span class="dot-target" aria-hidden="true">.</span></h2>
+        <div class="section-header">
+          <span class="section-prompt">$</span>
+          <span class="section-cmd">git log ./writing/</span>
+          <span class="section-cmd-flag">--oneline -5</span>
+          <span class="section-number">04<span class="dot-target" aria-hidden="true">.</span></span>
+        </div>
+        <h2 class="section-heading" style="position:absolute;left:-9999px;">writing</h2>
         <hr class="section-rule" role="presentation" />
 
         <ul class="writing-list" role="list">
           {blogPosts.length > 0 ? (
             blogPosts.map((post) => (
               <li>
-                <a href={post.url} class="writing-row hover-row motion-stagger" target="_blank" rel="noopener noreferrer">
+                <a href={post.url} class="writing-row motion-stagger" target="_blank" rel="noopener noreferrer">
                   <time class="writing-date" datetime={post.datetime}>{post.date}</time>
                   <span class="writing-title">{post.title}</span>
                   <span class="writing-arrow" aria-hidden="true">&rarr;</span>
@@ -232,13 +282,13 @@ const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
             ))
           ) : (
             <li>
-              <p class="writing-empty">Posts are taking a coffee break. Visit the blog directly.</p>
+              <p class="writing-empty">posts taking a coffee break. visit the blog directly.</p>
             </li>
           )}
         </ul>
 
         <a href="https://ralphdev.bearblog.dev/" class="writing-view-all motion-fade" target="_blank" rel="noopener noreferrer">
-          View all posts <span aria-hidden="true">&rarr;</span>
+          view all posts <span aria-hidden="true">&rarr;</span>
         </a>
       </div>
     </section>
@@ -246,23 +296,36 @@ const blogPosts = await getBlogPosts(BLOG_FEED_URL, MAX_POSTS);
     <!-- 05. Contact -->
     <section class="section" id="contact">
       <div class="section-inner">
-        <span class="section-number motion-fade">05.</span>
+        <div class="section-header">
+          <span class="section-prompt">$</span>
+          <span class="section-cmd">echo "let's build"</span>
+          <span class="section-cmd-flag">| mail -s hi</span>
+          <span class="section-number">05<span class="dot-target" aria-hidden="true">.</span></span>
+        </div>
         <h2 class="contact-cta motion-fade">
-          Let's work<br />together<span class="dot-target" aria-hidden="true">&#8203;</span><span class="contact-period">.</span>
+          let's work<br />together<span class="contact-period">_</span>
         </h2>
         <hr class="section-rule" role="presentation" />
 
         <div class="contact-links">
-          <a href="mailto:ralphmungcal09@gmail.com" class="contact-link motion-stagger">Email</a>
-          <a href="https://www.linkedin.com/in/ralphjonasmungcal" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-          <a href="https://www.upwork.com/o/profiles/users/_~01108375a06953763f/" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">Upwork</a>
+          <a href="mailto:ralphmungcal09@gmail.com" class="contact-link motion-stagger">email</a>
+          <a href="https://www.linkedin.com/in/ralphjonasmungcal" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">linkedin</a>
+          <a href="https://www.upwork.com/o/profiles/users/_~01108375a06953763f/" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">upwork</a>
         </div>
       </div>
 
       <footer class="site-footer">
-        Ralph Jonas Mungcal &copy; {currentYear}
+        <span>process exited — ralph jonas mungcal &copy; {currentYear}</span>
+        <span aria-hidden="true">[ctrl+c to detach]</span>
       </footer>
     </section>
+
+    <!-- Keyboard Nav Toast -->
+    <div class="kbd-toast" id="kbd-toast" aria-live="polite">
+      <span class="kbd-toast-hint">g</span>
+      <span>then</span>
+      <kbd>h</kbd><kbd>a</kbd><kbd>p</kbd><kbd>s</kbd><kbd>w</kbd><kbd>c</kbd>
+    </div>
   </main>
 
   <script>

--- a/src/scripts/home.ts
+++ b/src/scripts/home.ts
@@ -1,455 +1,214 @@
-type DelayValue = number | ((index: number) => number);
-type MotionOptions = Omit<KeyframeAnimationOptions, 'delay'> & {
-  delay?: DelayValue;
-};
-type DotState = 'hidden' | 'homing' | 'resting' | 'rolled';
 type PostHogCaptureProps = Record<string, number | string>;
 type PostHogClient = {
   capture: (eventName: string, properties?: PostHogCaptureProps) => void;
 };
 
-const DEFAULT_EASING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-function revealMotionElements() {
-  document.querySelectorAll<HTMLElement>('.motion-fade, .motion-letter, .motion-stagger').forEach((element) => {
-    element.style.opacity = '1';
-    element.style.transform = 'none';
+function revealStaticContent() {
+  document.querySelectorAll<HTMLElement>('.hero-name-letter, .motion-fade, .motion-stagger').forEach((el) => {
+    el.style.opacity = '1';
+    el.style.transform = 'none';
   });
 }
 
-function setStatValues() {
-  document.querySelectorAll<HTMLElement>('.about-stat-number[data-count]').forEach((element) => {
-    element.textContent = `${element.dataset.count ?? '0'}+`;
+function setStatValuesFinal() {
+  document.querySelectorAll<HTMLElement>('.about-stat-number[data-count]').forEach((el) => {
+    el.textContent = `${el.dataset.count ?? '0'}+`;
   });
 }
 
-function animateElements(
-  targets: Iterable<Element> | ArrayLike<Element>,
-  keyframes: PropertyIndexedKeyframes,
-  options: MotionOptions = {}
-) {
-  return Array.from(targets).map((target, index) => {
-    const { delay, ...rest } = options;
+/* ---------- Typewriter hero subtitle ---------- */
+function runTypewriter() {
+  const el = document.querySelector<HTMLElement>('.hero-subtitle');
+  const textSpan = el?.querySelector<HTMLElement>('.hero-subtitle-text');
+  if (!el || !textSpan) return;
 
-    return (target as HTMLElement).animate(keyframes, {
-      fill: 'forwards',
-      easing: DEFAULT_EASING,
-      ...rest,
-      delay: typeof delay === 'function' ? delay(index) : delay
-    });
-  });
+  const full = el.dataset.typewriter ?? textSpan.textContent ?? '';
+  if (prefersReducedMotion) {
+    textSpan.textContent = full;
+    return;
+  }
+
+  textSpan.textContent = '';
+  let i = 0;
+  const speed = 18;
+  const tick = () => {
+    if (i <= full.length) {
+      textSpan.textContent = full.slice(0, i);
+      i += 1;
+      window.setTimeout(tick, speed);
+    }
+  };
+  // Small delay so it feels like the shell booted
+  window.setTimeout(tick, 350);
 }
 
-function observeInView(
-  target: Element | string,
-  callback: (element: Element) => void,
-  { amount = 0 }: { amount?: number } = {}
-) {
-  const elements = typeof target === 'string'
-    ? Array.from(document.querySelectorAll(target))
-    : [target];
-
-  if (!elements.length) {
+/* ---------- Stat counter ---------- */
+function runStatCounter() {
+  if (prefersReducedMotion) {
+    setStatValuesFinal();
     return;
   }
 
   const observer = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
-      if (!entry.isIntersecting) {
-        return;
-      }
-
+      if (!entry.isIntersecting) return;
       observer.unobserve(entry.target);
-      callback(entry.target);
-    });
-  }, { threshold: amount });
 
-  elements.forEach((element) => observer.observe(element));
+      entry.target.querySelectorAll<HTMLElement>('.about-stat-number[data-count]').forEach((el) => {
+        const target = Number.parseInt(el.dataset.count ?? '0', 10);
+        const duration = 1000;
+        const start = performance.now();
+        const step = (now: number) => {
+          const p = Math.min((now - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - p, 3);
+          el.textContent = `${Math.round(eased * target)}+`;
+          if (p < 1) requestAnimationFrame(step);
+        };
+        requestAnimationFrame(step);
+      });
+    });
+  }, { threshold: 0.25 });
+
+  const about = document.getElementById('about');
+  if (about) observer.observe(about);
 }
 
-const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-const supportsElementAnimations = typeof Element.prototype.animate === 'function';
-
-if (!prefersReducedMotion && supportsElementAnimations) {
-  animateElements(
-    document.querySelectorAll('.hero-name-letter'),
-    { opacity: ['0', '1'], transform: ['translateY(100%)', 'translateY(0)'] },
-    { duration: 600, delay: (index) => index * 50 }
-  );
-
-  animateElements(
-    document.querySelectorAll('.hero .motion-fade'),
-    { opacity: ['0', '1'], transform: ['translateY(20px)', 'translateY(0)'] },
-    { duration: 800, delay: (index) => 800 + index * 150 }
-  );
-
-  const scrollIndicator = document.querySelector<HTMLElement>('.hero-scroll');
-  const scrollDot = document.querySelector<HTMLElement>('.scroll-dot');
-  const heroPeriod = document.querySelector<HTMLElement>('.hero-period');
-  const contactPeriod = document.querySelector<HTMLElement>('.contact-period');
-  const hero = document.querySelector<HTMLElement>('.hero');
-  const sections = Array.from(document.querySelectorAll<HTMLElement>('.section'));
-
-  if (scrollDot && hero && sections.length > 0) {
-    let state: DotState = 'hidden';
-    let currentIndex = -1;
-    let ticking = false;
-    let pulseAnimation: Animation | null = null;
-    let rollTimeoutA: number | null = null;
-    let rollTimeoutB: number | null = null;
-    let homingFrame: number | null = null;
-    let returnFrame: number | null = null;
-
-    let dotX = 0;
-    let dotY = 0;
-
-    const DOT_SIZE = 10;
-    const DOT_RADIUS = DOT_SIZE / 2;
-    const DOT_SIDE_GAP = 12;
-    const HOMING_SPEED = 0.13;
-    const SNAP_THRESHOLD = 0.5;
-
-    function positionDotAt(x: number, y: number) {
-      scrollDot.style.left = `${x}px`;
-      scrollDot.style.top = `${y}px`;
-    }
-
-    function getDotTarget(index: number) {
-      const marker = sections[index]?.querySelector<HTMLElement>('.dot-target');
-      if (!marker) {
-        return { x: window.innerWidth / 2, y: 60 };
-      }
-
-      const rect = marker.getBoundingClientRect();
-      return {
-        x: rect.right + DOT_SIDE_GAP,
-        y: rect.top + rect.height * 0.5 - DOT_RADIUS
-      };
-    }
-
-    function getActiveIndex() {
-      let active = 0;
-
-      sections.forEach((section, index) => {
-        const marker = section.querySelector<HTMLElement>('.dot-target');
-        if (marker) {
-          if (marker.getBoundingClientRect().top <= window.innerHeight * 0.75) {
-            active = index;
-          }
-          return;
-        }
-
-        if (window.scrollY + window.innerHeight >= section.offsetTop) {
-          active = index;
-        }
-      });
-
-      return Math.min(active, sections.length - 1);
-    }
-
-    function clearRollTimeouts() {
-      if (rollTimeoutA !== null) {
-        window.clearTimeout(rollTimeoutA);
-        rollTimeoutA = null;
-      }
-
-      if (rollTimeoutB !== null) {
-        window.clearTimeout(rollTimeoutB);
-        rollTimeoutB = null;
-      }
-    }
-
-    function cancelHoming() {
-      if (homingFrame !== null) {
-        cancelAnimationFrame(homingFrame);
-        homingFrame = null;
-      }
-
-      if (pulseAnimation) {
-        pulseAnimation.cancel();
-        pulseAnimation = null;
-      }
-    }
-
-    function cancelReturn() {
-      if (returnFrame !== null) {
-        cancelAnimationFrame(returnFrame);
-        returnFrame = null;
-      }
-    }
-
-    function resetRolling() {
-      clearRollTimeouts();
-
-      if (state === 'rolled') {
-        scrollDot.classList.remove('scroll-dot--rolling', 'scroll-dot--settled');
-        scrollDot.style.opacity = '';
-        if (contactPeriod) {
-          contactPeriod.style.opacity = '';
-        }
-      }
-    }
-
-    function startHoming(targetIndex: number) {
-      cancelHoming();
-      cancelReturn();
-      clearRollTimeouts();
-
-      if (targetIndex < sections.length - 1) {
-        resetRolling();
-      }
-
-      state = 'homing';
-      currentIndex = targetIndex;
-
-      const tick = () => {
-        const target = getDotTarget(currentIndex);
-
-        dotX += (target.x - dotX) * HOMING_SPEED;
-        dotY += (target.y - dotY) * HOMING_SPEED;
-        positionDotAt(dotX, dotY);
-
-        if (Math.abs(target.x - dotX) < SNAP_THRESHOLD && Math.abs(target.y - dotY) < SNAP_THRESHOLD) {
-          dotX = target.x;
-          dotY = target.y;
-          positionDotAt(dotX, dotY);
-          homingFrame = null;
-
-          pulseAnimation = scrollDot.animate(
-            { transform: ['scale(1)', 'scale(1.2)', 'scale(1)'] },
-            { duration: 300, easing: DEFAULT_EASING }
-          );
-
-          if (currentIndex === sections.length - 1 && contactPeriod) {
-            rollTimeoutA = window.setTimeout(() => {
-              const periodRect = contactPeriod.getBoundingClientRect();
-              const periodCenterX = periodRect.left + periodRect.width / 2;
-              const periodCenterY = periodRect.top + periodRect.height / 2;
-
-              scrollDot.classList.add('scroll-dot--rolling');
-              positionDotAt(periodCenterX, periodCenterY);
-
-              rollTimeoutB = window.setTimeout(() => {
-                scrollDot.classList.add('scroll-dot--settled');
-                scrollDot.style.opacity = '0';
-                contactPeriod.style.opacity = '1';
-                state = 'rolled';
-              }, 550);
-            }, 200);
-
-            return;
-          }
-
-          state = 'resting';
-          return;
-        }
-
-        homingFrame = requestAnimationFrame(tick);
-      };
-
-      homingFrame = requestAnimationFrame(tick);
-    }
-
-    const onScroll = () => {
-      if (ticking) {
-        return;
-      }
-
-      ticking = true;
-
-      requestAnimationFrame(() => {
-        const scrollY = window.scrollY;
-        const heroBottom = hero.offsetHeight * 0.7;
-
-        if (scrollIndicator) {
-          const fade = Math.max(1 - scrollY / (window.innerHeight * 0.3), 0);
-          scrollIndicator.style.opacity = String(fade);
-        }
-
-        if (scrollY <= heroBottom) {
-          if (state !== 'hidden') {
-            cancelHoming();
-            clearRollTimeouts();
-            resetRolling();
-
-            if (heroPeriod) {
-              heroPeriod.style.opacity = '0';
-              cancelReturn();
-
-              const returnTick = () => {
-                const heroRect = heroPeriod.getBoundingClientRect();
-                const targetX = heroRect.left + heroRect.width / 2;
-                const targetY = heroRect.top + heroRect.height / 2;
-
-                dotX += (targetX - dotX) * 0.2;
-                dotY += (targetY - dotY) * 0.2;
-                positionDotAt(dotX, dotY);
-
-                if (Math.abs(targetX - dotX) < 0.5 && Math.abs(targetY - dotY) < 0.5) {
-                  scrollDot.classList.remove('scroll-dot--visible');
-                  heroPeriod.style.opacity = '1';
-                  returnFrame = null;
-                  return;
-                }
-
-                returnFrame = requestAnimationFrame(returnTick);
-              };
-
-              returnFrame = requestAnimationFrame(returnTick);
-            } else {
-              scrollDot.classList.remove('scroll-dot--visible');
-            }
-
-            state = 'hidden';
-            currentIndex = -1;
-
-            if (contactPeriod) {
-              contactPeriod.style.opacity = '';
-            }
-          }
-
-          ticking = false;
-          return;
-        }
-
-        scrollDot.classList.add('scroll-dot--visible');
-        cancelReturn();
-
-        if (heroPeriod) {
-          heroPeriod.style.opacity = '0';
-        }
-
-        const activeIndex = getActiveIndex();
-
-        if (state === 'hidden') {
-          if (heroPeriod) {
-            const heroRect = heroPeriod.getBoundingClientRect();
-            dotX = heroRect.left + heroRect.width / 2;
-            dotY = heroRect.top + heroRect.height / 2;
-          } else {
-            const target = getDotTarget(activeIndex);
-            dotX = target.x;
-            dotY = target.y - 100;
-          }
-
-          positionDotAt(dotX, dotY);
-          startHoming(activeIndex);
-          ticking = false;
-          return;
-        }
-
-        if (state === 'resting') {
-          const target = getDotTarget(currentIndex);
-          dotX = target.x;
-          dotY = target.y;
-          positionDotAt(dotX, dotY);
-
-          if (activeIndex !== currentIndex) {
-            startHoming(activeIndex);
-          }
-        } else if (state === 'rolled' && activeIndex < currentIndex) {
-          resetRolling();
-          scrollDot.classList.add('scroll-dot--visible');
-          startHoming(activeIndex);
-        } else if (state === 'homing' && activeIndex !== currentIndex) {
-          startHoming(activeIndex);
-        }
-
-        ticking = false;
-      });
-    };
-
-    window.addEventListener('scroll', onScroll, { passive: true });
-  } else if (scrollIndicator) {
-    window.addEventListener('scroll', () => {
-      const fade = Math.max(1 - window.scrollY / (window.innerHeight * 0.3), 0);
-      scrollIndicator.style.opacity = String(fade);
-    }, { passive: true });
+/* ---------- Section entrance stagger (subtle) ---------- */
+function runEntranceAnimations() {
+  if (prefersReducedMotion) {
+    revealStaticContent();
+    return;
   }
 
-  document.querySelectorAll('.section').forEach((section) => {
-    observeInView(section, () => {
-      animateElements(
-        section.querySelectorAll('.motion-fade'),
-        { opacity: ['0', '1'], transform: ['translateY(20px)', 'translateY(0)'] },
-        { duration: 600, delay: (index) => index * 100 }
-      );
-    }, { amount: 0.1 });
+  // Hero letters cascade
+  document.querySelectorAll<HTMLElement>('.hero-name-letter').forEach((el, i) => {
+    el.style.opacity = '0';
+    el.style.transform = 'translateY(40%)';
+    el.animate(
+      [
+        { opacity: 0, transform: 'translateY(40%)' },
+        { opacity: 1, transform: 'translateY(0)' }
+      ],
+      { duration: 400, delay: i * 40, fill: 'forwards', easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }
+    );
   });
 
-  document.querySelectorAll('.section').forEach((section) => {
-    observeInView(section, () => {
-      animateElements(
-        section.querySelectorAll('.motion-stagger'),
-        { opacity: ['0', '1'], transform: ['translateY(16px)', 'translateY(0)'] },
-        { duration: 500, delay: (index) => index * 60 }
-      );
-    }, { amount: 0.05 });
-  });
+  // Section stagger/fade on scroll-in
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return;
+      observer.unobserve(entry.target);
 
-  let statsCounted = false;
-  observeInView('#about', () => {
-    if (statsCounted) {
-      return;
-    }
-
-    statsCounted = true;
-
-    document.querySelectorAll<HTMLElement>('.about-stat-number[data-count]').forEach((element) => {
-      const target = Number.parseInt(element.dataset.count ?? '0', 10);
-      const duration = 1200;
-      const start = performance.now();
-
-      const step = (now: number) => {
-        const progress = Math.min((now - start) / duration, 1);
-        const eased = 1 - Math.pow(1 - progress, 3);
-        element.textContent = `${Math.round(eased * target)}+`;
-
-        if (progress < 1) {
-          requestAnimationFrame(step);
-        }
-      };
-
-      requestAnimationFrame(step);
+      const targets = entry.target.querySelectorAll<HTMLElement>('.motion-fade, .motion-stagger');
+      targets.forEach((el, i) => {
+        el.style.opacity = '0';
+        el.style.transform = 'translateY(8px)';
+        el.animate(
+          [
+            { opacity: 0, transform: 'translateY(8px)' },
+            { opacity: 1, transform: 'translateY(0)' }
+          ],
+          { duration: 360, delay: i * 40, fill: 'forwards', easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }
+        );
+      });
     });
-  }, { amount: 0.2 });
+  }, { threshold: 0.08 });
 
-  let contactHighlighted = false;
-  observeInView('#contact', () => {
-    if (contactHighlighted) {
-      return;
-    }
-
-    contactHighlighted = true;
-
-    document.querySelectorAll<HTMLElement>('.contact-link').forEach((link, index) => {
-      const start = 500 + index * 550;
-      window.setTimeout(() => link.classList.add('is-highlighted'), start);
-      window.setTimeout(() => link.classList.remove('is-highlighted'), start + 400);
-    });
-  }, { amount: 0.05 });
-} else {
-  revealMotionElements();
-  setStatValues();
+  document.querySelectorAll('.section').forEach((s) => observer.observe(s));
 }
 
-const posthog = (window as Window & { posthog?: PostHogClient }).posthog;
+/* ---------- Signature: vim-style keyboard nav ---------- */
+type SectionKey = 'h' | 'a' | 'p' | 's' | 'w' | 'c';
+const SECTION_MAP: Record<SectionKey, string> = {
+  h: 'hero',
+  a: 'about',
+  p: 'projects',
+  s: 'side-projects',
+  w: 'writing',
+  c: 'contact'
+};
 
+function wireKeyboardNav() {
+  const toast = document.getElementById('kbd-toast');
+  let prefixActive = false;
+  let prefixTimer: number | null = null;
+
+  const showToast = () => {
+    if (!toast) return;
+    toast.classList.add('kbd-toast--visible');
+  };
+  const hideToast = () => {
+    if (!toast) return;
+    toast.classList.remove('kbd-toast--visible');
+  };
+
+  const endPrefix = () => {
+    prefixActive = false;
+    hideToast();
+    if (prefixTimer !== null) {
+      window.clearTimeout(prefixTimer);
+      prefixTimer = null;
+    }
+  };
+
+  window.addEventListener('keydown', (ev) => {
+    const target = ev.target as HTMLElement | null;
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+      return;
+    }
+    if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
+
+    const key = ev.key.toLowerCase();
+
+    if (!prefixActive) {
+      if (key === 'g') {
+        prefixActive = true;
+        showToast();
+        prefixTimer = window.setTimeout(endPrefix, 1500);
+      }
+      return;
+    }
+
+    // prefixActive === true
+    if (key in SECTION_MAP) {
+      ev.preventDefault();
+      const id = SECTION_MAP[key as SectionKey];
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+        (window as Window & { posthog?: PostHogClient }).posthog?.capture('keyboard_nav', { section: id });
+      }
+    }
+    endPrefix();
+  });
+}
+
+/* ---------- Bootstrap ---------- */
+const supportsAnimate = typeof Element.prototype.animate === 'function';
+if (!prefersReducedMotion && supportsAnimate) {
+  runEntranceAnimations();
+  runTypewriter();
+  runStatCounter();
+} else {
+  revealStaticContent();
+  setStatValuesFinal();
+}
+
+wireKeyboardNav();
+
+/* ---------- PostHog ---------- */
+const posthog = (window as Window & { posthog?: PostHogClient }).posthog;
 if (posthog) {
   const sectionIds = ['hero', 'about', 'projects', 'side-projects', 'writing', 'contact'];
   const viewedSections = new Set<string>();
 
   const sectionObserver = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
-      if (!entry.isIntersecting) {
-        return;
-      }
-
+      if (!entry.isIntersecting) return;
       const id = entry.target.id;
-      if (viewedSections.has(id)) {
-        return;
-      }
-
+      if (viewedSections.has(id)) return;
       viewedSections.add(id);
       sectionObserver.unobserve(entry.target);
       posthog.capture('section_viewed', { section: id });
@@ -457,47 +216,34 @@ if (posthog) {
   }, { threshold: 0.3 });
 
   sectionIds.forEach((id) => {
-    const element = document.getElementById(id);
-    if (element) {
-      sectionObserver.observe(element);
-    }
+    const el = document.getElementById(id);
+    if (el) sectionObserver.observe(el);
   });
 
   const depthMarks = new Set<number>();
   let depthTicking = false;
-
   const onScrollDepth = () => {
-    if (depthTicking) {
-      return;
-    }
-
+    if (depthTicking) return;
     depthTicking = true;
-
     requestAnimationFrame(() => {
       const docHeight = document.documentElement.scrollHeight - window.innerHeight;
       if (docHeight > 0) {
-        const scrollPercent = Math.round((window.scrollY / docHeight) * 100);
-
+        const pct = Math.round((window.scrollY / docHeight) * 100);
         [25, 50, 75, 100].forEach((mark) => {
-          if (scrollPercent >= mark && !depthMarks.has(mark)) {
+          if (pct >= mark && !depthMarks.has(mark)) {
             depthMarks.add(mark);
             posthog.capture('scroll_depth', { percent: mark });
           }
         });
       }
-
       depthTicking = false;
     });
   };
-
   window.addEventListener('scroll', onScrollDepth, { passive: true });
 
-  document.addEventListener('click', (event) => {
-    const link = (event.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
-    if (!link) {
-      return;
-    }
-
+  document.addEventListener('click', (ev) => {
+    const link = (ev.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
+    if (!link) return;
     const href = link.href;
 
     if (link.closest('#contact')) {
@@ -507,7 +253,6 @@ if (posthog) {
       });
       return;
     }
-
     if (link.closest('#writing')) {
       posthog.capture('writing_clicked', {
         title: link.querySelector('.writing-title')?.textContent?.trim() || href,
@@ -515,7 +260,6 @@ if (posthog) {
       });
       return;
     }
-
     if (link.closest('#side-projects')) {
       posthog.capture('side_project_clicked', {
         name: link.querySelector('.side-project-name')?.textContent?.trim() || href,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,20 +1,31 @@
-/* ===== CSS Custom Properties ===== */
+/* ===== Design Tokens — Terminal Brutalism ===== */
 :root {
-  --color-bg: #0a0a0a;
-  --color-text: #fafafa;
-  --color-text-muted: #666666;
-  --color-accent: #ff3333;
-  --color-border: #1a1a1a;
-  --color-surface: #111111;
-  --color-accent-subtle: rgba(255, 51, 51, 0.08);
-  --color-text-faint: rgba(255, 255, 255, 0.2);
+  --color-bg: #fdfbf0;
+  --color-bg-alt: #f5f1dc;
+  --color-ink: #0a0a0a;
+  --color-ink-soft: #3a3a3a;
+  --color-ink-muted: #6b6b66;
+  --color-border: #0a0a0a;
+  --color-accent: #ff6a1a;
+  --color-accent-soft: #ffd9b8;
+  --color-cursor: #ff6a1a;
+  --color-surface: #fffdf3;
 
-  --font-heading: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --shadow-hard: 4px 4px 0 0 var(--color-border);
+  --shadow-hard-lg: 6px 6px 0 0 var(--color-border);
+  --shadow-hard-sm: 2px 2px 0 0 var(--color-border);
 
-  --max-width: 1200px;
-  --section-padding-y: clamp(80px, 12vh, 160px);
-  --section-padding-x: clamp(1.5rem, 5vw, 6rem);
+  --border-w: 2px;
+
+  --font-mono: 'JetBrains Mono', 'IBM Plex Mono', 'Geist Mono', ui-monospace,
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+
+  --max-width: 1180px;
+  --section-padding-y: clamp(3.5rem, 9vh, 7rem);
+  --section-padding-x: clamp(1.25rem, 5vw, 5rem);
+
+  color-scheme: light;
 }
 
 /* ===== Reset ===== */
@@ -33,6 +44,12 @@ html {
   overflow-x: hidden;
   scroll-behavior: smooth;
   background-color: var(--color-bg);
+  /* Subtle scanline/grid texture */
+  background-image:
+    linear-gradient(var(--color-bg-alt) 1px, transparent 1px),
+    linear-gradient(90deg, var(--color-bg-alt) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-position: -1px -1px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -48,14 +65,16 @@ body {
 }
 
 body {
-  font-family: var(--font-body);
-  color: var(--color-text);
-  background-color: var(--color-bg);
-  line-height: 1.6;
+  font-family: var(--font-mono);
+  color: var(--color-ink);
+  background-color: transparent;
+  line-height: 1.55;
+  font-size: 15px;
+  letter-spacing: 0;
 }
 
 a {
-  color: var(--color-text);
+  color: var(--color-ink);
   text-decoration: none;
 }
 
@@ -65,7 +84,18 @@ img {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-heading);
-  font-weight: 500;
-  line-height: 1.1;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  line-height: 1.05;
+  color: var(--color-ink);
+}
+
+::selection {
+  background: var(--color-accent);
+  color: var(--color-bg);
+}
+
+:focus-visible {
+  outline: var(--border-w) solid var(--color-accent);
+  outline-offset: 3px;
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,87 +1,181 @@
-/* ===== Base Layout ===== */
-
+/* ===== Layout ===== */
 .portfolio-page {
   position: relative;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2rem) var(--section-padding-x);
 }
 
+/* ===== Top Shell Bar ===== */
+.shell-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  padding: 0.5rem 0.875rem;
+  box-shadow: var(--shadow-hard-sm);
+  font-size: 0.75rem;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.shell-bar-dots {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.shell-bar-dot {
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-bg-alt);
+}
+
+.shell-bar-dot--live {
+  background: var(--color-accent);
+}
+
+.shell-bar-path {
+  flex: 1;
+  color: var(--color-ink-soft);
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell-bar-hint {
+  display: none;
+  color: var(--color-ink-muted);
+  font-size: 0.7rem;
+}
+
+.shell-bar-hint kbd {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+}
+
+@media (min-width: 720px) {
+  .shell-bar-hint {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
+  }
+}
+
+/* ===== Section ===== */
 .section {
   position: relative;
   width: 100%;
-  padding: var(--section-padding-y) var(--section-padding-x);
+  padding: clamp(2rem, 5vw, 3.5rem) 0;
+  scroll-margin-top: 1.5rem;
 }
 
 .section-inner {
   width: 100%;
-  max-width: var(--max-width);
-  margin: 0 auto;
 }
 
-/* ===== Section Header Pattern ===== */
+/* Section header as a shell prompt */
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.6rem 0.9rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: var(--border-w) dashed var(--color-border);
+}
+
+.section-prompt {
+  color: var(--color-accent);
+  font-weight: 700;
+  font-size: 0.95rem;
+  user-select: none;
+}
+
+.section-cmd {
+  font-size: clamp(1.05rem, 2.2vw, 1.4rem);
+  font-weight: 700;
+  color: var(--color-ink);
+  letter-spacing: -0.01em;
+}
+
+.section-cmd-flag {
+  color: var(--color-ink-muted);
+  font-weight: 500;
+}
 
 .section-number {
-  font-family: var(--font-heading);
-  font-size: clamp(0.875rem, 1.2vw, 1rem);
-  font-weight: 300;
-  color: var(--color-text-muted);
-  letter-spacing: 0.1em;
-  margin-bottom: 0.5rem;
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.05em;
 }
 
-.section-heading {
-  font-family: var(--font-heading);
-  font-size: clamp(2rem, 5vw, 3.5rem);
-  font-weight: 700;
-  color: var(--color-text);
-  letter-spacing: -0.02em;
-  text-transform: uppercase;
-  margin-bottom: 1rem;
-}
-
+/* Dot target preserved for JS compat but hidden visually */
 .dot-target {
   color: transparent;
   pointer-events: none;
   user-select: none;
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
 }
 
 .section-rule {
-  width: 100%;
-  height: 1px;
-  background: var(--color-border);
-  border: none;
-  margin-bottom: clamp(2rem, 4vw, 3.5rem);
+  display: none;
 }
 
 /* ===== Hero ===== */
-
 .hero {
-  min-height: 100svh;
+  min-height: calc(100svh - 4rem);
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: var(--section-padding-x);
   position: relative;
+  padding: clamp(2rem, 6vw, 4rem) 0;
 }
 
 .hero-inner {
   width: 100%;
-  max-width: var(--max-width);
-  margin: 0 auto;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-lg);
+  padding: clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.hero-whoami {
+  font-size: 0.8rem;
+  color: var(--color-ink-muted);
+  margin-bottom: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.hero-whoami-prompt {
+  color: var(--color-accent);
+  font-weight: 700;
 }
 
 .hero-name {
-  font-family: var(--font-heading);
-  font-size: clamp(4rem, 15vw, 12rem);
-  font-weight: 700;
-  line-height: 0.9;
+  font-family: var(--font-mono);
+  font-size: clamp(2.75rem, 11vw, 7rem);
+  font-weight: 800;
+  line-height: 0.95;
   letter-spacing: -0.04em;
-  text-transform: uppercase;
-  color: var(--color-text);
+  color: var(--color-ink);
   margin: 0;
 }
 
 .hero-name-line {
   display: block;
-  overflow: hidden;
 }
 
 .hero-name-letter {
@@ -90,231 +184,121 @@
 
 .hero-period {
   color: var(--color-accent);
-  transition: opacity 0.4s ease;
 }
 
 .hero-subtitle {
-  font-family: var(--font-body);
-  font-size: clamp(1rem, 2vw, 1.25rem);
+  font-family: var(--font-mono);
+  font-size: clamp(0.95rem, 1.6vw, 1.125rem);
   font-weight: 400;
-  color: var(--color-text-muted);
-  margin-top: clamp(1.5rem, 3vw, 2.5rem);
-  max-width: 45ch;
+  color: var(--color-ink-soft);
+  margin-top: clamp(1.25rem, 2.5vw, 1.75rem);
+  max-width: 52ch;
   line-height: 1.6;
+  min-height: 3.2em;
+}
+
+.hero-subtitle-text {
+  display: inline;
+}
+
+.hero-cursor {
+  display: inline-block;
+  width: 0.55ch;
+  height: 1em;
+  vertical-align: -0.12em;
+  background: var(--color-cursor);
+  margin-left: 2px;
+  animation: cursor-blink 1s steps(2) infinite;
+}
+
+@keyframes cursor-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+.hero-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+
+.hero-tag {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-ink);
+  background: var(--color-bg-alt);
+  border: var(--border-w) solid var(--color-border);
+  padding: 0.3rem 0.65rem;
+  box-shadow: var(--shadow-hard-sm);
 }
 
 .hero-scroll {
-  position: absolute;
-  bottom: clamp(1.5rem, 3vw, 2.5rem);
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  flex-direction: column;
+  margin-top: clamp(2rem, 4vw, 3rem);
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.05em;
 }
 
-.hero-scroll-text {
-  font-family: var(--font-heading);
-  font-size: 0.6875rem;
-  font-weight: 500;
-  letter-spacing: 0.3em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
+.hero-scroll-text,
+.hero-scroll-arrow {
+  display: inline;
 }
 
 .hero-scroll-arrow {
-  font-size: 1.25rem;
   color: var(--color-accent);
-  animation: bounce-arrow 1.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
-}
-
-@keyframes bounce-arrow {
-  0%, 100% { transform: translateY(0); opacity: 1; }
-  50% { transform: translateY(8px); opacity: 0.5; }
+  animation: bounce-arrow 1.6s ease-in-out infinite;
 }
 
 .hero-scroll-line {
-  width: 1px;
-  height: 40px;
-  background: linear-gradient(to bottom, var(--color-accent), transparent);
+  display: none;
 }
 
-/* ===== Shared Row Hover Pattern ===== */
-
-.hover-row {
-  position: relative;
-  transition: padding-left 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+@keyframes bounce-arrow {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(3px); }
 }
 
-.hover-row::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 0;
-  background: var(--color-accent);
-  transition: width 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.hover-row:hover::before {
-  width: 3px;
-}
-
-.hover-row:hover {
-  padding-left: 1.25rem;
-}
-
-/* ===== Project List ===== */
-
-.project-list {
-  list-style: none;
-}
-
-.project-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: clamp(1rem, 2vw, 1.5rem) 0;
-  border-bottom: 1px solid var(--color-border);
-  cursor: default;
-}
-
-@media (min-width: 768px) {
-  .project-row {
-    flex-direction: row;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 2rem;
-  }
-}
-
-.project-name {
-  font-family: var(--font-heading);
-  font-size: clamp(1.125rem, 2.5vw, 1.5rem);
-  font-weight: 500;
-  color: var(--color-text);
-  letter-spacing: -0.01em;
-  transition: color 0.3s ease;
-  flex-shrink: 0;
-}
-
-.project-row:hover .project-name {
-  color: var(--color-accent);
-}
-
-.project-tech {
-  font-family: var(--font-body);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text);
-  letter-spacing: 0.04em;
-  white-space: nowrap;
+/* ===== Shared Card ===== */
+.brut-card {
+  border: var(--border-w) solid var(--color-border);
   background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  padding: 0.25rem 0.75rem;
-  border-radius: 0;
-  transition: border-color 0.3s ease;
+  box-shadow: var(--shadow-hard);
+  padding: clamp(0.875rem, 2vw, 1.25rem);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.project-row:hover .project-tech {
+.brut-card:hover,
+.brut-card:focus-visible {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard-lg);
+}
+
+.brut-card:focus-visible {
+  outline: none;
   border-color: var(--color-accent);
 }
 
-.project-desc {
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
-  line-height: 1.6;
-  max-width: 55ch;
-}
-
-@media (min-width: 768px) {
-  .project-row {
-    flex-wrap: wrap;
-  }
-
-  .project-desc {
-    flex-basis: 100%;
-    margin-top: 0.25rem;
-  }
-}
-
-/* Other projects subheading */
-.other-heading {
-  font-family: var(--font-heading);
-  font-size: clamp(0.875rem, 1.2vw, 1rem);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-top: clamp(2.5rem, 4vw, 4rem);
-  margin-bottom: 1rem;
-}
-
-.compact-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: clamp(0.75rem, 1.5vw, 1rem) 0;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.compact-row:hover::before {
-  width: 2px;
-}
-
-@media (min-width: 768px) {
-  .compact-row {
-    flex-direction: row;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 2rem;
-  }
-}
-
-.compact-name {
-  font-family: var(--font-heading);
-  font-size: clamp(0.9375rem, 1.5vw, 1.125rem);
-  font-weight: 500;
-  color: var(--color-text);
-  transition: color 0.3s ease;
-}
-
-.compact-row:hover .compact-name {
-  color: var(--color-accent);
-}
-
-.compact-tech {
-  font-family: var(--font-body);
-  font-size: 0.6875rem;
-  font-weight: 500;
-  color: var(--color-text);
-  letter-spacing: 0.04em;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  padding: 0.1875rem 0.625rem;
-  transition: border-color 0.3s ease;
-}
-
-.compact-row:hover .compact-tech {
-  border-color: var(--color-accent);
+a.brut-card {
+  color: inherit;
+  display: block;
 }
 
 /* ===== About ===== */
-
 .about-grid {
   display: flex;
   flex-direction: column;
-  gap: clamp(2.5rem, 5vw, 4rem);
+  gap: clamp(1.25rem, 3vw, 1.75rem);
 }
 
-@media (min-width: 768px) {
+@media (min-width: 900px) {
   .about-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: clamp(3rem, 6vw, 6rem);
+    grid-template-columns: 1.15fr 1fr;
+    gap: 1.5rem;
     align-items: start;
   }
 }
@@ -322,433 +306,560 @@
 .about-col-left {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2rem);
+  gap: 1rem;
 }
 
 .about-col-right {
   display: flex;
   flex-direction: column;
-  gap: clamp(2rem, 4vw, 2.5rem);
+  gap: 1rem;
 }
 
 .about-name {
-  font-family: var(--font-heading);
-  font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--color-text);
-  border: 2px solid var(--color-border);
-  padding: 0.75rem 1.25rem;
   display: inline-block;
-  transition: border-color 0.3s ease, color 0.3s ease;
-}
-
-.about-name:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-accent);
+  padding: 0.45rem 0.85rem;
+  box-shadow: var(--shadow-hard-sm);
+  align-self: flex-start;
 }
 
 .about-bio {
-  font-family: var(--font-body);
-  font-size: clamp(1rem, 1.8vw, 1.125rem);
-  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  color: var(--color-ink-soft);
   line-height: 1.7;
-  max-width: 55ch;
+  max-width: 58ch;
 }
 
-/* Stats */
+.about-bio::before {
+  content: '# ';
+  color: var(--color-ink-muted);
+}
+
 .about-stats {
-  display: flex;
-  gap: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
 }
 
 .about-stat {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  padding: 0.75rem 0.9rem;
 }
 
 .about-stat-number {
-  font-family: var(--font-heading);
-  font-size: clamp(2.5rem, 5vw, 3.5rem);
-  font-weight: 700;
+  font-family: var(--font-mono);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 800;
   letter-spacing: -0.03em;
-  color: var(--color-text);
+  color: var(--color-accent);
   line-height: 1;
 }
 
 .about-stat-label {
-  font-family: var(--font-heading);
-  font-size: 0.75rem;
-  font-weight: 400;
-  color: var(--color-text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-/* Focus tags */
-.focus-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.focus-item {
-  font-family: var(--font-heading);
-  font-size: 0.8125rem;
+  font-size: 0.7rem;
   font-weight: 500;
-  color: var(--color-text);
-  letter-spacing: 0.03em;
-  padding: 0.5rem 1.25rem;
-  border: 1px solid var(--color-border);
-  transition: border-color 0.3s ease, color 0.3s ease;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.04em;
 }
 
-.focus-item:hover {
-  border-color: var(--color-accent);
+.about-stat-label::before {
+  content: '> ';
   color: var(--color-accent);
 }
 
-/* Tech stack */
+.focus-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.focus-item {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-ink);
+  padding: 0.25rem 0.6rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-bg-alt);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.1s ease, background 0.1s ease;
+}
+
+.focus-item::before {
+  content: '#';
+  color: var(--color-accent);
+  margin-right: 0.15rem;
+}
+
+.focus-item:hover {
+  background: var(--color-accent-soft);
+  transform: translate(-1px, -1px);
+}
+
 .about-stack {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .about-stack-label {
-  font-family: var(--font-heading);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-muted);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.about-stack-label::before {
+  content: '$ ls ';
+  color: var(--color-accent);
 }
 
 .about-stack-items {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .about-stack-item {
-  font-family: var(--font-heading);
-  font-size: 0.8125rem;
+  font-size: 0.72rem;
   font-weight: 500;
-  color: var(--color-text);
-  letter-spacing: 0.04em;
-  padding: 0.5rem 1.25rem;
+  color: var(--color-ink);
+  padding: 0.2rem 0.55rem;
   background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  transition: border-color 0.3s ease, background 0.3s ease;
+  border: var(--border-w) solid var(--color-border);
 }
 
 .about-stack-item:hover {
-  border-color: var(--color-accent);
-  background: var(--color-accent-subtle);
+  background: var(--color-accent-soft);
 }
 
-/* ===== Writing (Blog) ===== */
-
-.writing-list {
+/* ===== Projects ===== */
+.project-list {
   list-style: none;
-}
-
-.writing-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: clamp(1rem, 2vw, 1.25rem) 0;
-  border-bottom: 1px solid var(--color-border);
-  text-decoration: none;
-  color: inherit;
-}
-
-@media (min-width: 768px) {
-  .writing-row {
-    flex-direction: row;
-    align-items: baseline;
-    gap: 2rem;
-  }
-}
-
-.writing-date {
-  font-family: var(--font-heading);
-  font-size: 0.8125rem;
-  font-weight: 400;
-  color: var(--color-text-muted);
-  letter-spacing: 0.05em;
-  flex-shrink: 0;
-  min-width: 7ch;
-}
-
-.writing-title {
-  font-family: var(--font-heading);
-  font-size: clamp(1rem, 2vw, 1.25rem);
-  font-weight: 500;
-  color: var(--color-text);
-  flex: 1;
-  transition: color 0.3s ease;
-}
-
-.writing-row:hover .writing-title {
-  color: var(--color-accent);
-}
-
-.writing-arrow {
-  font-size: 1.25rem;
-  color: var(--color-text-muted);
-  transition: transform 0.3s ease, color 0.3s ease;
-  margin-left: auto;
-  flex-shrink: 0;
-}
-
-@media (max-width: 767px) {
-  .writing-arrow {
-    font-size: 1rem;
-    align-self: flex-end;
-  }
-}
-
-.writing-row:hover .writing-arrow {
-  transform: translateX(6px);
-  color: var(--color-accent);
-}
-
-.writing-empty {
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
-  font-style: italic;
-  padding: clamp(1rem, 2vw, 1.25rem) 0;
-}
-
-.writing-view-all {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: clamp(1.5rem, 3vw, 2rem);
-  font-family: var(--font-heading);
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-text-muted);
-  letter-spacing: 0.05em;
-  text-decoration: none;
-  transition: color 0.3s ease, gap 0.3s ease;
-}
-
-.writing-view-all:hover {
-  color: var(--color-accent);
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 0.75rem;
 }
 
-/* ===== Side Projects ===== */
+@media (min-width: 720px) {
+  .project-list {
+    grid-template-columns: 1fr 1fr;
+  }
+}
 
+.project-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.9rem 1rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.project-row:hover,
+.project-row:focus-within {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard-lg);
+}
+
+.project-name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  letter-spacing: -0.01em;
+}
+
+.project-name::before {
+  content: './';
+  color: var(--color-accent);
+}
+
+.project-tech {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--color-ink-soft);
+  letter-spacing: 0.02em;
+}
+
+.project-desc {
+  font-size: 0.825rem;
+  color: var(--color-ink-soft);
+  line-height: 1.55;
+}
+
+.project-desc::before {
+  content: '// ';
+  color: var(--color-ink-muted);
+}
+
+/* Other work — compact */
+.other-heading {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.05em;
+  margin: clamp(1.25rem, 3vw, 2rem) 0 0.6rem;
+}
+
+.other-heading::before {
+  content: '$ ls ./other-work/ — ';
+  color: var(--color-accent);
+}
+
+.compact-row {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px dashed var(--color-border);
+  background: transparent;
+  transition: background 0.1s ease, padding-left 0.15s ease;
+}
+
+.compact-row:hover {
+  background: var(--color-accent-soft);
+  padding-left: 1rem;
+}
+
+.compact-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.compact-name::before {
+  content: '— ';
+  color: var(--color-accent);
+}
+
+.compact-tech {
+  font-size: 0.7rem;
+  color: var(--color-ink-muted);
+}
+
+/* ===== Side Projects ===== */
 .side-project-list {
   list-style: none;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 720px) {
+  .side-project-list {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
 }
 
 .side-project-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: clamp(1.25rem, 2.5vw, 1.75rem) 0;
-  border-bottom: 1px solid var(--color-border);
-  text-decoration: none;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard);
   color: inherit;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.side-project-row:hover,
+.side-project-row:focus-visible {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard-lg);
+  background: var(--color-accent-soft);
+  outline: none;
 }
 
 .side-project-info {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.3rem;
+  min-width: 0;
 }
 
 .side-project-name {
-  font-family: var(--font-heading);
-  font-size: clamp(1.125rem, 2.5vw, 1.5rem);
-  font-weight: 500;
-  color: var(--color-text);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-ink);
   letter-spacing: -0.01em;
-  transition: color 0.3s ease;
 }
 
-.side-project-row:hover .side-project-name {
+.side-project-name::before {
+  content: '~/ ';
   color: var(--color-accent);
 }
 
 .side-project-desc {
-  font-family: var(--font-body);
-  font-size: 0.875rem;
-  color: var(--color-text-muted);
-  line-height: 1.6;
-  max-width: 55ch;
+  font-size: 0.78rem;
+  color: var(--color-ink-soft);
+  line-height: 1.5;
 }
 
 .side-project-arrow {
-  font-size: 1.25rem;
-  color: var(--color-text-muted);
-  transition: transform 0.3s ease, color 0.3s ease;
+  font-size: 1.15rem;
+  color: var(--color-accent);
+  font-weight: 700;
   flex-shrink: 0;
+  transition: transform 0.2s ease;
 }
 
 .side-project-row:hover .side-project-arrow {
-  transform: translateX(6px);
+  transform: translateX(4px);
+}
+
+/* ===== Writing ===== */
+.writing-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.writing-row {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+  flex-wrap: wrap;
+}
+
+.writing-row:hover,
+.writing-row:focus-visible {
+  transform: translate(-1px, -1px);
+  box-shadow: var(--shadow-hard);
+  background: var(--color-accent-soft);
+  outline: none;
+}
+
+.writing-date {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  flex-shrink: 0;
+  min-width: 7ch;
+  font-variant-numeric: tabular-nums;
+}
+
+.writing-date::before {
+  content: '[';
+  color: var(--color-ink-muted);
+}
+
+.writing-date::after {
+  content: ']';
+  color: var(--color-ink-muted);
+}
+
+.writing-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-ink);
+  flex: 1;
+  min-width: 0;
+}
+
+.writing-arrow {
+  font-size: 0.95rem;
+  color: var(--color-ink-muted);
+  transition: transform 0.2s ease, color 0.2s ease;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.writing-row:hover .writing-arrow {
+  transform: translateX(3px);
   color: var(--color-accent);
 }
 
-/* ===== Contact ===== */
+.writing-empty {
+  font-size: 0.85rem;
+  color: var(--color-ink-muted);
+  padding: 0.75rem 0.5rem;
+}
 
+.writing-empty::before {
+  content: '$ cat posts/*.md → ';
+  color: var(--color-accent);
+}
+
+.writing-view-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-ink);
+  text-decoration: none;
+  padding: 0.4rem 0.75rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.writing-view-all::before {
+  content: '$ ';
+  color: var(--color-accent);
+}
+
+.writing-view-all:hover,
+.writing-view-all:focus-visible {
+  transform: translate(-1px, -1px);
+  background: var(--color-accent-soft);
+  outline: none;
+}
+
+/* ===== Contact ===== */
 .contact-cta {
-  font-family: var(--font-heading);
-  font-size: clamp(2.5rem, 8vw, 5rem);
-  font-weight: 700;
-  line-height: 0.95;
-  letter-spacing: -0.03em;
-  text-transform: uppercase;
-  color: var(--color-text);
-  margin-bottom: clamp(2rem, 4vw, 3rem);
+  font-family: var(--font-mono);
+  font-size: clamp(1.75rem, 5vw, 3rem);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+  margin-bottom: 1.25rem;
 }
 
 .contact-period {
   color: var(--color-accent);
-  opacity: 0;
-  transition: opacity 0.25s ease;
+  opacity: 1;
 }
 
 .contact-links {
   display: flex;
   flex-wrap: wrap;
-  gap: clamp(1.5rem, 3vw, 2.5rem);
+  gap: 0.6rem;
 }
 
 .contact-link {
-  font-family: var(--font-heading);
-  font-size: clamp(1rem, 1.5vw, 1.125rem);
-  font-weight: 500;
-  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-ink);
   text-decoration: none;
-  position: relative;
-  letter-spacing: 0.02em;
-  transition: color 0.3s ease;
+  padding: 0.55rem 1rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-.contact-link::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 0;
-  height: 1px;
-  background: var(--color-accent);
-  transition: width 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+.contact-link::before {
+  content: '> ';
+  color: var(--color-accent);
 }
 
 .contact-link:hover,
+.contact-link:focus-visible,
 .contact-link.is-highlighted {
-  color: var(--color-accent);
-}
-
-.contact-link:hover::after,
-.contact-link.is-highlighted::after {
-  width: 100%;
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard-lg);
+  background: var(--color-accent);
+  color: var(--color-ink);
+  outline: none;
 }
 
 /* ===== Footer ===== */
-
 .site-footer {
-  padding: clamp(2rem, 4vw, 3rem) var(--section-padding-x);
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  color: var(--color-text-faint);
-  letter-spacing: 0.03em;
-  max-width: var(--max-width);
-  margin: 0 auto;
+  padding: 2rem 0 1rem;
+  font-size: 0.75rem;
+  color: var(--color-ink-muted);
+  border-top: var(--border-w) dashed var(--color-border);
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: space-between;
 }
 
-/* ===== Scroll Dot ===== */
+.site-footer::before {
+  content: '$ exit';
+  color: var(--color-accent);
+  font-weight: 700;
+}
 
+/* ===== Scroll Dot (disabled in brutalist theme) ===== */
 .scroll-dot {
+  display: none !important;
+}
+
+/* ===== Keyboard Nav Toast ===== */
+.kbd-toast {
   position: fixed;
-  width: 10px;
-  height: 10px;
-  background: var(--color-accent);
-  border-radius: 50%;
-  z-index: 100;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  z-index: 200;
+  padding: 0.6rem 0.85rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard);
+  font-size: 0.8rem;
+  color: var(--color-ink);
   opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
   pointer-events: none;
-  will-change: transform, opacity;
-  box-shadow: 0 0 12px color-mix(in srgb, var(--color-accent) 40%, transparent);
-  transition: opacity 0.4s ease;
 }
 
-.scroll-dot--visible {
+.kbd-toast--visible {
   opacity: 1;
+  transform: translateY(0);
 }
 
-.scroll-dot--rolling {
-  transition: left 0.5s cubic-bezier(0.16, 1, 0.3, 1), top 0.3s ease, opacity 0.4s ease;
+.kbd-toast kbd {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  background: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  padding: 0.05rem 0.35rem;
+  border-radius: 2px;
+  margin-right: 0.2rem;
 }
 
-.scroll-dot--settled {
-  transition: opacity 0.3s ease;
-}
-
-/* ===== Focus Styles ===== */
-
-:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 3px;
-}
-
-.hover-row:focus-visible {
-  padding-left: 1.25rem;
-}
-
-.hover-row:focus-visible::before {
-  width: 3px;
-}
-
-.compact-row:focus-visible::before {
-  width: 2px;
-}
-
-.focus-item:focus-visible,
-.about-stack-item:focus-visible {
-  border-color: var(--color-accent);
+.kbd-toast-hint {
   color: var(--color-accent);
+  font-weight: 700;
+  margin-right: 0.35rem;
 }
 
-.contact-link:focus-visible {
-  color: var(--color-accent);
-}
-
-.contact-link:focus-visible::after {
-  width: 100%;
-}
-
-/* ===== Motion Initial States ===== */
-/* These get animated by Motion JS. Set initial hidden state. */
-
-.motion-fade {
-  opacity: 0;
-  transform: translateY(20px);
-}
-
-.motion-letter {
-  display: inline-block;
-  opacity: 0;
-  transform: translateY(100%);
-}
-
+/* ===== Motion initial states (kept for compat; minimal) ===== */
+.motion-fade,
+.motion-letter,
 .motion-stagger {
-  opacity: 0;
-  transform: translateY(16px);
+  /* Static by default in brutalist theme — JS may animate entrance */
+  opacity: 1;
+  transform: none;
 }
 
 /* ===== Reduced Motion ===== */
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -758,14 +869,12 @@
     transition-duration: 0.01ms !important;
   }
 
-  .motion-fade,
-  .motion-letter,
-  .motion-stagger {
-    opacity: 1;
-    transform: none;
+  .hero-cursor {
+    animation: none;
+    opacity: 0.6;
   }
 
-  .scroll-dot {
-    display: none;
+  .hero-scroll-arrow {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- Rework homepage into terminal-brutalist aesthetic
- Drop dark mode: remove theme toggle, persisted preference, and system-preference bootstrap
- Rebuild 404 page as terminal shell error

## Test plan
- [x] `npm run build` passes
- [ ] Verify hero, sections, keyboard nav (g+a/p/s/w/c) in browser
- [ ] Confirm no `data-theme` flash on load
- [ ] 404 page renders with requested path injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)