### PR TITLE
feat(blog): related posts block on post pages

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { getPublishedPosts, formatPubDateLong } from '../../utils/blog';
+import { getPublishedPosts, formatPubDateLong, getRelatedPosts } from '../../utils/blog';
 import '../../styles/blog.css';
 
 export async function getStaticPaths() {
@@ -19,6 +19,7 @@ const allPosts = await getPublishedPosts();
 const currentIndex = allPosts.findIndex((p) => p.id === post.id);
 const prevPost = currentIndex >= 0 ? allPosts[currentIndex + 1] : undefined;
 const nextPost = currentIndex > 0 ? allPosts[currentIndex - 1] : undefined;
+const relatedPosts = getRelatedPosts(post, allPosts, 3);
 
 const canonicalURL = post.data.canonical
   ?? `https://ralphjonas.com/blog/${post.id}/`;
@@ -98,6 +99,33 @@ const breadcrumb = {
         <Content />
       </div>
     </article>
+
+    {relatedPosts.length > 0 && (
+      <aside class="related-posts" aria-labelledby="related-posts-heading">
+        <div class="related-posts-header">
+          <span class="related-posts-prompt">$</span>
+          <span class="related-posts-cmd">grep -l related --tags</span>
+        </div>
+        <h2 id="related-posts-heading" class="related-posts-title">related reading</h2>
+        <ul class="related-posts-list">
+          {relatedPosts.map((related) => (
+            <li class="related-posts-item">
+              <a href={`/blog/${related.id}/`} class="related-posts-link">
+                <span class="related-posts-link-title">{related.data.title}</span>
+                <span class="related-posts-link-desc">{related.data.description}</span>
+                {related.data.tags.length > 0 && (
+                  <span class="related-posts-link-tags">
+                    {related.data.tags.map((tag) => (
+                      <span class="related-posts-link-tag">#{tag}</span>
+                    ))}
+                  </span>
+                )}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </aside>
+    )}
 
     <nav class="post-nav" aria-label="Post navigation">
       {prevPost ? (

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -345,6 +345,96 @@
   margin: 1.5rem 0;
 }
 
+.related-posts {
+  margin-top: 3.5rem;
+  padding-top: 1.5rem;
+  border-top: var(--border-w) solid var(--color-border);
+}
+
+.related-posts-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.related-posts-prompt {
+  color: var(--color-accent);
+  font-weight: 800;
+}
+
+.related-posts-cmd {
+  font-weight: 700;
+  color: var(--color-ink-soft);
+}
+
+.related-posts-title {
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-weight: 800;
+  margin: 0 0 1rem;
+  color: var(--color-ink);
+}
+
+.related-posts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.related-posts-item {
+  margin: 0;
+}
+
+.related-posts-link {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  color: var(--color-ink);
+  text-decoration: none;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.related-posts-link:hover,
+.related-posts-link:focus-visible {
+  transform: translate(-2px, -2px);
+  background: var(--color-accent);
+  outline: none;
+}
+
+.related-posts-link-title {
+  font-weight: 800;
+  font-size: 1rem;
+}
+
+.related-posts-link-desc {
+  font-size: 0.88rem;
+  color: var(--color-ink-soft);
+  line-height: 1.45;
+}
+
+.related-posts-link:hover .related-posts-link-desc,
+.related-posts-link:focus-visible .related-posts-link-desc {
+  color: var(--color-ink);
+}
+
+.related-posts-link-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--color-ink-soft);
+}
+
+.related-posts-link-tag {
+  font-weight: 700;
+}
+
 .post-nav {
   display: flex;
   justify-content: space-between;

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -24,3 +24,26 @@ export function formatPubDateLong(date: Date): string {
 export function toIsoDate(date: Date): string {
   return date.toISOString().split('T')[0];
 }
+
+export function getRelatedPosts(
+  current: BlogEntry,
+  all: BlogEntry[],
+  limit = 3
+): BlogEntry[] {
+  const currentTags = new Set(current.data.tags);
+  if (currentTags.size === 0) return [];
+
+  const scored = all
+    .filter((p) => p.id !== current.id)
+    .map((p) => {
+      const shared = p.data.tags.filter((t) => currentTags.has(t)).length;
+      return { post: p, shared };
+    })
+    .filter((entry) => entry.shared > 0)
+    .sort((a, b) => {
+      if (b.shared !== a.shared) return b.shared - a.shared;
+      return b.post.data.pubDate.valueOf() - a.post.data.pubDate.valueOf();
+    });
+
+  return scored.slice(0, limit).map((entry) => entry.post);
+}


### PR DESCRIPTION
## Summary
- Add `getRelatedPosts(current, all, limit)` to `src/utils/blog.ts` — ranks posts by shared-tag count, tiebreak by recency.
- Render a "related reading" aside on `/blog/<slug>/` above the prev/next nav. Shows up to 3 tag-matched posts with title, description, and tags.
- Styled in the existing terminal-brutalism language in `blog.css`.
- Block only renders when there's at least one tag overlap — no empty "related" section for orphan posts.

Part of the post-migration SEO push: strengthens internal linking so crawlers (and readers) can traverse topic clusters.

## Test plan
- [x] `npm run build` succeeds
- [x] `/blog/how-to-become-ai-native/` renders the related block with 3 tag-matched entries
- [ ] Visual check on a post with no tag overlap — block should be absent
- [ ] Hover/focus states match other blog nav links