### PR TITLE
feat(blog): add back-to-posts button on post pages

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -68,6 +68,11 @@ const breadcrumb = {
       <span>ralph@jonas:~/writing/{post.id} — post.md</span>
     </div>
 
+    <a href="/blog/" class="post-back" aria-label="Back to all posts">
+      <span class="post-back-arrow" aria-hidden="true">&larr;</span>
+      <span class="post-back-label">all posts</span>
+    </a>
+
     <article>
       <div class="post-meta">
         <span class="post-meta-prompt">$</span>

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -345,6 +345,33 @@
   margin: 1.5rem 0;
 }
 
+.post-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  text-decoration: none;
+  background: var(--color-surface);
+  border: var(--border-w) solid var(--color-border);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.post-back:hover,
+.post-back:focus-visible {
+  transform: translate(-2px, -2px);
+  background: var(--color-accent);
+  outline: none;
+}
+
+.post-back-arrow {
+  font-weight: 800;
+}
+
 .related-posts {
   margin-top: 3.5rem;
   padding-top: 1.5rem;


### PR DESCRIPTION
## Summary
- Adds a top-of-page "← all posts" link below the shell bar on every `/blog/<slug>/` page.
- Styled to match the terminal-brutalism language of the other blog nav links.
- Gives readers arriving from a shared link or search result a one-tap path back to the archive without scrolling to the bottom.

## Test plan
- [x] `npm run build` succeeds
- [x] Link rendered on each post page
- [ ] Visual check: hover/focus state matches `.post-nav-link`
- [ ] Works with keyboard focus (aria-label present)