### PR TITLE
style(blog): polish post page spacing, touch targets, focus, motion

### DIFF
--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -107,6 +107,10 @@
   outline: none;
 }
 
+.blog-list-link:focus-visible {
+  box-shadow: inset 3px 0 0 var(--color-accent);
+}
+
 .blog-list-date {
   font-size: 0.82rem;
   color: var(--color-ink-muted);
@@ -118,6 +122,7 @@
   font-weight: 700;
   color: var(--color-ink);
   letter-spacing: -0.01em;
+  text-wrap: balance;
 }
 
 .blog-list-arrow {
@@ -187,6 +192,7 @@
   letter-spacing: -0.03em;
   line-height: 1.05;
   margin-bottom: 1.1rem;
+  text-wrap: balance;
 }
 
 .post-period {
@@ -349,6 +355,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  min-height: 44px;
+  margin-top: clamp(-2rem, -3vh, -1rem);
   margin-bottom: 1.5rem;
   padding: 0.5rem 0.85rem;
   font-size: 0.85rem;
@@ -370,6 +378,7 @@
 
 .post-back-arrow {
   font-weight: 800;
+  line-height: 1;
 }
 
 .related-posts {
@@ -437,16 +446,23 @@
 .related-posts-link-title {
   font-weight: 800;
   font-size: 1rem;
+  text-wrap: balance;
 }
 
 .related-posts-link-desc {
   font-size: 0.88rem;
   color: var(--color-ink-soft);
   line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .related-posts-link:hover .related-posts-link-desc,
-.related-posts-link:focus-visible .related-posts-link-desc {
+.related-posts-link:focus-visible .related-posts-link-desc,
+.related-posts-link:hover .related-posts-link-tags,
+.related-posts-link:focus-visible .related-posts-link-tags {
   color: var(--color-ink);
 }
 
@@ -473,6 +489,9 @@
 }
 
 .post-nav-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
   font-size: 0.88rem;
   font-weight: 700;
   color: var(--color-ink);
@@ -488,4 +507,27 @@
   transform: translate(-2px, -2px);
   background: var(--color-accent);
   outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .post-back,
+  .post-nav-link,
+  .related-posts-link,
+  .blog-list-link,
+  .blog-list-arrow {
+    transition: background 0.12s ease;
+  }
+
+  .post-back:hover,
+  .post-back:focus-visible,
+  .post-nav-link:hover,
+  .post-nav-link:focus-visible,
+  .related-posts-link:hover,
+  .related-posts-link:focus-visible {
+    transform: none;
+  }
+
+  .blog-list-link:hover .blog-list-arrow {
+    transform: none;
+  }
 }


### PR DESCRIPTION
## Summary
Final-pass detail work on the blog post pages after the back-button + related-posts features landed.

**Layout**
- Tighten the vertical rhythm between the shell bar and the "← all posts" button. The stack previously felt top-heavy.

**Touch & accessibility**
- 44px minimum touch target on `.post-back` and `.post-nav-link` (was ~32px — below WCAG 2.5.5).
- Visible keyboard focus marker on blog-index rows (inset 3px accent bar) — the previous bg-only state was too quiet.

**Related-post cards**
- Line-clamp descriptions to 3 lines so card heights are uniform.
- Promote tag color to ink on hover/focus so text reads against the orange fill.

**Typography**
- `text-wrap: balance` on post title, related-card title, and blog-list title — kills single-word orphans.

**Motion**
- `prefers-reduced-motion: reduce` suppresses the 2px hover/focus translate on all link buttons while keeping the background color change intact.

## Test plan
- [x] `npm run build` succeeds
- [ ] Visual check: back button sits closer to shell bar on post pages
- [ ] Keyboard tab through blog index — left accent bar visible on focus
- [ ] Tab through post-nav + back button — bg turns orange, focus reads cleanly
- [ ] Related-post card with long description clips to 3 lines
- [ ] With `prefers-reduced-motion` on, hovering nav links changes bg but does not translate
- [ ] Mobile (≤640px): touch targets feel comfortable for thumbs