### PR TITLE
feat(analytics): posthog tracking on blog pages

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -58,7 +58,13 @@ const breadcrumb = {
     {post.data.canonical && <link rel="canonical" href={post.data.canonical} />}
   </Fragment>
 
-  <main class="post-page">
+  <main
+    class="post-page"
+    data-slug={post.id}
+    data-title={post.data.title}
+    data-tags={post.data.tags.join(',')}
+    data-pub-date={post.data.pubDate.toISOString()}
+  >
     <div class="blog-shell-bar" role="banner">
       <div class="blog-shell-bar-dots" aria-hidden="true">
         <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
@@ -149,4 +155,8 @@ const breadcrumb = {
       )}
     </nav>
   </main>
+
+  <script>
+    import '../../scripts/blog-post';
+  </script>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -54,4 +54,8 @@ const description = 'Notes on software engineering, AI integration, career, and 
       <a href="/rss.xml" class="post-nav-link">rss.xml</a>
     </div>
   </main>
+
+  <script>
+    import '../../scripts/blog-index';
+  </script>
 </BaseLayout>

--- a/src/scripts/blog-index.ts
+++ b/src/scripts/blog-index.ts
@@ -1,0 +1,42 @@
+type PostHogCaptureProps = Record<string, number | string>;
+type PostHogClient = {
+  capture: (eventName: string, properties?: PostHogCaptureProps) => void;
+};
+
+const posthog = (window as Window & { posthog?: PostHogClient }).posthog;
+const main = document.querySelector<HTMLElement>('main.blog-page');
+
+if (posthog && main) {
+  const items = Array.from(document.querySelectorAll<HTMLAnchorElement>('.blog-list-link'));
+  posthog.capture('blog_index_viewed', { post_count: items.length });
+
+  const slugFromHref = (href: string): string => {
+    try {
+      const path = new URL(href).pathname;
+      const match = path.match(/^\/blog\/([^/]+)\/?$/);
+      return match ? match[1] : '';
+    } catch {
+      return '';
+    }
+  };
+
+  document.addEventListener('click', (ev) => {
+    const link = (ev.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
+    if (!link) return;
+    const href = link.href;
+
+    if (link.matches('.blog-list-link')) {
+      const position = items.indexOf(link) + 1;
+      posthog.capture('blog_post_clicked', {
+        slug: slugFromHref(href),
+        title: link.querySelector('.blog-list-title')?.textContent?.trim() ?? '',
+        position
+      });
+      return;
+    }
+
+    if (link.matches('.post-nav-link') && href.endsWith('/rss.xml')) {
+      posthog.capture('blog_rss_clicked');
+    }
+  });
+}

--- a/src/scripts/blog-post.ts
+++ b/src/scripts/blog-post.ts
@@ -1,0 +1,129 @@
+type PostHogCaptureProps = Record<string, number | string>;
+type PostHogClient = {
+  capture: (eventName: string, properties?: PostHogCaptureProps) => void;
+};
+
+const posthog = (window as Window & { posthog?: PostHogClient }).posthog;
+const main = document.querySelector<HTMLElement>('main.post-page');
+
+if (posthog && main) {
+  const slug = main.dataset.slug ?? '';
+  const title = main.dataset.title ?? '';
+  const tags = main.dataset.tags ?? '';
+  const pubDate = main.dataset.pubDate ?? '';
+
+  posthog.capture('blog_post_viewed', { slug, title, tags, pub_date: pubDate });
+
+  /* ---------- Scroll depth ---------- */
+  const depthMarks = new Set<number>();
+  let depthTicking = false;
+  const onScrollDepth = () => {
+    if (depthTicking) return;
+    depthTicking = true;
+    requestAnimationFrame(() => {
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      if (docHeight > 0) {
+        const pct = Math.round((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach((mark) => {
+          if (pct >= mark && !depthMarks.has(mark)) {
+            depthMarks.add(mark);
+            posthog.capture('blog_scroll_depth', { slug, percent: mark });
+          }
+        });
+      }
+      depthTicking = false;
+    });
+  };
+  window.addEventListener('scroll', onScrollDepth, { passive: true });
+
+  /* ---------- Read time (active dwell, visibility-gated) ---------- */
+  let activeMs = 0;
+  let lastTick = Date.now();
+  let isVisible = document.visibilityState === 'visible';
+
+  const flushActive = () => {
+    if (isVisible) activeMs += Date.now() - lastTick;
+    lastTick = Date.now();
+  };
+
+  document.addEventListener('visibilitychange', () => {
+    flushActive();
+    isVisible = document.visibilityState === 'visible';
+  });
+
+  const readMarks = new Set<number>();
+  const thresholds = [30, 60, 120, 300];
+  const checkRead = () => {
+    flushActive();
+    const seconds = Math.floor(activeMs / 1000);
+    thresholds.forEach((mark) => {
+      if (seconds >= mark && !readMarks.has(mark)) {
+        readMarks.add(mark);
+        posthog.capture('blog_read_time', { slug, seconds: mark });
+      }
+    });
+    if (readMarks.size === thresholds.length) clearInterval(intervalId);
+  };
+  const intervalId = window.setInterval(checkRead, 5000);
+
+  /* ---------- Clicks ---------- */
+  const slugFromHref = (href: string): string => {
+    try {
+      const path = new URL(href).pathname;
+      const match = path.match(/^\/blog\/([^/]+)\/?$/);
+      return match ? match[1] : '';
+    } catch {
+      return '';
+    }
+  };
+
+  document.addEventListener('click', (ev) => {
+    const link = (ev.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
+    if (!link) return;
+    const href = link.href;
+
+    if (link.matches('.post-back')) {
+      posthog.capture('blog_post_back_clicked', { from_slug: slug });
+      return;
+    }
+
+    if (link.matches('.related-posts-link')) {
+      posthog.capture('blog_related_clicked', {
+        from_slug: slug,
+        to_slug: slugFromHref(href),
+        to_title: link.querySelector('.related-posts-link-title')?.textContent?.trim() ?? ''
+      });
+      return;
+    }
+
+    if (link.matches('.post-nav-link')) {
+      const text = link.textContent?.trim() ?? '';
+      let direction = 'other';
+      if (text.startsWith('\u2190')) direction = 'prev';
+      else if (text.endsWith('\u2192')) direction = 'next';
+      else if (text.includes('cd ~/')) direction = 'home';
+      posthog.capture('blog_post_nav_clicked', {
+        from_slug: slug,
+        direction,
+        to_slug: slugFromHref(href),
+        href
+      });
+      return;
+    }
+
+    if (link.closest('.post-content')) {
+      try {
+        const url = new URL(href);
+        if (url.hostname && url.hostname !== location.hostname) {
+          posthog.capture('blog_external_link_clicked', {
+            slug,
+            href,
+            text: (link.textContent?.trim() ?? '').slice(0, 120)
+          });
+        }
+      } catch {
+        /* non-http href, ignore */
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Adds custom PostHog events for the blog so we can see which posts resonate, how far readers actually get, and which internal/external links they follow. PostHog is already initialized in `BaseLayout` — this layer only covers blog-specific signals.

### Events

**Post page** (`src/scripts/blog-post.ts`)
- `blog_post_viewed` — `{ slug, title, tags, pub_date }` from `data-*` attrs on `<main class="post-page">`.
- `blog_scroll_depth` — `{ slug, percent }` at 25/50/75/100.
- `blog_read_time` — `{ slug, seconds }` at 30/60/120/300. **Active dwell only** — visibility-gated so AFK / background-tab time doesn't inflate the metric.
- `blog_post_back_clicked` — top back button.
- `blog_related_clicked` — `{ from_slug, to_slug, to_title }`.
- `blog_post_nav_clicked` — `{ from_slug, direction: 'prev'|'next'|'home'|'other', to_slug, href }`.
- `blog_external_link_clicked` — outbound links inside `.post-content` only. `{ slug, href, text }`.

**Index page** (`src/scripts/blog-index.ts`)
- `blog_index_viewed` — `{ post_count }`.
- `blog_post_clicked` — `{ slug, title, position }` (1-based).
- `blog_rss_clicked`.

Both scripts no-op when `window.posthog` is unavailable (local dev w/o key, blockers) and scope themselves to the matching `<main>` so they can coexist safely under the shared layout.

## Test plan
- [x] `npm run build` succeeds
- [x] Data attrs present on post `<main>` (verified in built HTML)
- [x] Event names bundled into the per-page module script
- [ ] With PostHog key set, verify events fire in the PostHog Live Events view
- [ ] Switch tabs during a post — confirm `blog_read_time` does not advance while hidden
- [ ] Click a related card — `blog_related_clicked` fires with correct `from_slug` / `to_slug`
- [ ] Click an outbound link in post body — `blog_external_link_clicked` fires; internal `/blog/` link does not