### PR TITLE
feat(blog): add x account link and end-of-post follow cta

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -111,6 +111,28 @@ const breadcrumb = {
       </div>
     </article>
 
+    <aside class="post-follow" aria-labelledby="post-follow-heading">
+      <div class="post-follow-header">
+        <span class="post-follow-prompt">$</span>
+        <span class="post-follow-cmd">echo "liked this?"</span>
+      </div>
+      <h2 id="post-follow-heading" class="post-follow-title">
+        follow <span class="post-follow-handle">@ralphsenpaidev</span> on x
+      </h2>
+      <p class="post-follow-desc">
+        more notes on engineering, ai, and building things &mdash; usually before they land here.
+      </p>
+      <a
+        href="https://x.com/ralphsenpaidev"
+        class="post-follow-cta"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span class="post-follow-cta-arrow" aria-hidden="true">&rarr;</span>
+        <span>x.com/ralphsenpaidev</span>
+      </a>
+    </aside>
+
     {relatedPosts.length > 0 && (
       <aside class="related-posts" aria-labelledby="related-posts-heading">
         <div class="related-posts-header">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -368,6 +368,7 @@ const sideProjectItemList = {
         <div class="contact-links">
           <a href="mailto:ralphmungcal09@gmail.com" class="contact-link motion-stagger">email</a>
           <a href="https://www.linkedin.com/in/ralphjonasmungcal" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">linkedin</a>
+          <a href="https://x.com/ralphsenpaidev" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">x</a>
           <a href="https://www.upwork.com/o/profiles/users/_~01108375a06953763f/" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">upwork</a>
         </div>
       </div>

--- a/src/scripts/blog-post.ts
+++ b/src/scripts/blog-post.ts
@@ -87,6 +87,11 @@ if (posthog && main) {
       return;
     }
 
+    if (link.matches('.post-follow-cta')) {
+      posthog.capture('blog_follow_x_clicked', { slug, href });
+      return;
+    }
+
     if (link.matches('.related-posts-link')) {
       posthog.capture('blog_related_clicked', {
         from_slug: slug,

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -381,6 +381,104 @@
   line-height: 1;
 }
 
+.post-follow {
+  margin-top: 3.5rem;
+  padding: 1.5rem 1.25rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-bg-alt);
+  box-shadow: var(--shadow-hard);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.post-follow-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.post-follow-prompt {
+  color: var(--color-accent);
+  font-weight: 800;
+}
+
+.post-follow-cmd {
+  font-weight: 700;
+  color: var(--color-ink-soft);
+}
+
+.post-follow-title {
+  font-size: clamp(1.15rem, 2.25vw, 1.5rem);
+  font-weight: 800;
+  line-height: 1.15;
+  margin: 0;
+  color: var(--color-ink);
+  text-wrap: balance;
+}
+
+.post-follow-handle {
+  color: var(--color-accent);
+}
+
+.post-follow-desc {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--color-ink-soft);
+  max-width: 52ch;
+}
+
+.post-follow-cta {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 44px;
+  margin-top: 0.35rem;
+  padding: 0.55rem 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  text-decoration: none;
+  background: var(--color-surface);
+  border: var(--border-w) solid var(--color-border);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.post-follow-cta:hover,
+.post-follow-cta:focus-visible {
+  transform: translate(-2px, -2px);
+  background: var(--color-accent);
+  outline: none;
+}
+
+.post-follow-cta-arrow {
+  font-weight: 800;
+  line-height: 1;
+  transition: transform 0.12s ease;
+}
+
+.post-follow-cta:hover .post-follow-cta-arrow,
+.post-follow-cta:focus-visible .post-follow-cta-arrow {
+  transform: translateX(3px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .post-follow-cta,
+  .post-follow-cta-arrow {
+    transition: background 0.12s ease;
+  }
+
+  .post-follow-cta:hover,
+  .post-follow-cta:focus-visible,
+  .post-follow-cta:hover .post-follow-cta-arrow,
+  .post-follow-cta:focus-visible .post-follow-cta-arrow {
+    transform: none;
+  }
+}
+
 .related-posts {
   margin-top: 3.5rem;
   padding-top: 1.5rem;


### PR DESCRIPTION
## Summary
- Adds `x.com/ralphsenpaidev` to the Contact section on the home page (between LinkedIn and Upwork).
- Adds a "follow @ralphsenpaidev on x" CTA block at the end of every blog post, placed between the article body and the related-posts section.
- Tracks CTA clicks as `blog_follow_x_clicked` in PostHog with the post slug.

### Placement rationale
Readers who finish a post are the highest-intent audience for a follow ask. Putting the CTA there (not in a sidebar, not above the fold) captures that intent without being intrusive.

### Styling
Terminal-brutalism card: `bg-alt` fill with the hard-shadow border, terminal prompt header, and the standard accent-on-hover button treatment. Respects `prefers-reduced-motion`.

## Heads-up
`BaseLayout.astro` still references the older `@ItsRalphSenpai` handle in `sameAs`, `twitter:creator`, and `twitter:site`. Left unchanged here — happy to align those in a follow-up once you confirm the old account is retired.

## Test plan
- [x] `npm run build` succeeds
- [x] `/` contact links include `x` → `x.com/ralphsenpaidev`
- [x] Every `/blog/<slug>/` renders the follow CTA
- [ ] Visual: CTA sits cleanly between article and related posts
- [ ] Hover/focus: accent fill, arrow nudges right
- [ ] Keyboard: tab lands on CTA, focus visible
- [ ] PostHog: `blog_follow_x_clicked` fires with correct slug