### PR TITLE
feat(home): add ascii-art-gen to side projects

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,6 +27,7 @@ const featuredProjects = [
 const sideProjects = [
   { name: 'subconscious', url: 'https://subconsciousapp.co', description: 'Subscription tracking — take control of recurring expenses.' },
   { name: 'spot-the-synth', url: 'https://spotthesynth.com', description: 'Community-driven AI photo spotting and discussion.' },
+  { name: 'ascii-art-gen', url: 'https://ascii-art-gen.fly.dev/', description: 'Generate ASCII art from text and images, right in the browser.' },
   { name: 'the-leon-files', url: 'https://theleonfiles.com', description: 'Fan site — Leon Kennedy, Resident Evil.' }
 ];
 
@@ -298,6 +299,15 @@ const sideProjectItemList = {
               <div class="side-project-info">
                 <span class="side-project-name">spot-the-synth</span>
                 <p class="side-project-desc">community-driven ai photo spotting and discussion.</p>
+              </div>
+              <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://ascii-art-gen.fly.dev/" class="side-project-row motion-stagger" target="_blank" rel="noopener noreferrer">
+              <div class="side-project-info">
+                <span class="side-project-name">ascii-art-gen</span>
+                <p class="side-project-desc">generate ascii art from text and images, right in the browser.</p>
               </div>
               <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
             </a>


### PR DESCRIPTION
## Summary
Adds [ascii-art-gen.fly.dev](https://ascii-art-gen.fly.dev/) to the side projects section.

- New entry inserted third in the rendered list (before `the-leon-files`).
- Matching entry added to the `sideProjects` data array so the `ItemList` JSON-LD schema stays in sync with the visible UI.

## Test plan
- [x] `npm run build` succeeds
- [x] New row renders in `#side-projects`
- [x] `ascii-art-gen.fly.dev` present in JSON-LD output
- [ ] Visual: sits cleanly in list, arrow animates on hover like the others