### PR TITLE
feat(now): add /now page for ongoing side projects

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -284,6 +284,10 @@ const sideProjectItemList = {
         <h2 class="section-heading visually-hidden">Side Projects</h2>
         <hr class="section-rule" role="presentation" />
 
+        <a href="/now/" class="side-project-now-link motion-fade">
+          $ what am i up to now <span aria-hidden="true">&rarr;</span>
+        </a>
+
         <ul class="side-project-list" role="list">
           <li>
             <a href="https://subconsciousapp.co" class="side-project-row motion-stagger" target="_blank" rel="noopener noreferrer">

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -1,0 +1,128 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import '../styles/blog.css';
+import '../styles/now.css';
+
+type NowStatus = 'shipping' | 'building' | 'iterating' | 'maintenance';
+
+const nowProjects: Array<{
+  name: string;
+  url: string;
+  status: NowStatus;
+  update: string;
+}> = [
+  { name: 'ascii-art-gen',  url: 'https://ascii-art-gen.fly.dev/',  status: 'iterating', update: 'Polishing UX + adding image upload.' },
+  { name: 'subconscious',   url: 'https://subconsciousapp.co',      status: 'iterating', update: 'Iterating on notifications and export.' },
+  { name: 'spot-the-synth', url: 'https://spotthesynth.com',        status: 'iterating', update: 'Community moderation tooling next.' },
+  { name: 'the-leon-files', url: 'https://theleonfiles.com',        status: 'iterating', update: 'Content + UI touch-ups.' }
+];
+
+const NOW_UPDATED = '2026-04-22';
+
+const title = 'Now — Ralph Jonas Mungcal';
+const description = "What I'm currently building, shipping, and iterating on.";
+const canonicalURL = 'https://ralphjonas.com/now/';
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
+    { '@type': 'ListItem', position: 2, name: 'Now', item: canonicalURL }
+  ]
+};
+
+const nowItemList = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: "What Ralph Jonas Mungcal is working on now",
+  itemListElement: nowProjects.map((project, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    item: {
+      '@type': 'WebSite',
+      name: project.name,
+      url: project.url,
+      description: project.update,
+      creator: { '@id': 'https://ralphjonas.com/#person' }
+    }
+  }))
+};
+
+const formattedUpdated = new Date(`${NOW_UPDATED}T00:00:00Z`).toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+});
+---
+
+<BaseLayout title={title} description={description}>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumb)}></script>
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(nowItemList)}></script>
+  </Fragment>
+
+  <main class="now-page" data-project-count={nowProjects.length}>
+    <div class="blog-shell-bar" role="banner">
+      <div class="blog-shell-bar-dots" aria-hidden="true">
+        <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
+        <span class="blog-shell-bar-dot"></span>
+        <span class="blog-shell-bar-dot"></span>
+      </div>
+      <span>ralph@jonas:~/now — status.sh</span>
+    </div>
+
+    <div class="now-header">
+      <span class="now-header-prompt">$</span>
+      <span class="now-header-cmd">cat now.md</span>
+    </div>
+    <hr class="now-rule" role="presentation" />
+
+    <h1 class="now-title">
+      what i'm up to<span class="now-period">_</span>
+    </h1>
+
+    <p class="now-updated">
+      <span class="now-updated-label">last updated</span>
+      <time datetime={NOW_UPDATED}>{formattedUpdated}</time>
+    </p>
+
+    <p class="now-intro">
+      the side projects i'm actively iterating on right now. if something here catches your eye, pop into it or message me on x.
+    </p>
+
+    <ul class="now-list" role="list">
+      {nowProjects.map((project) => (
+        <li class="now-item">
+          <a
+            href={project.url}
+            class="now-project-row"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-name={project.name}
+            data-status={project.status}
+          >
+            <div class="now-project-head">
+              <span class="now-project-name">{project.name}</span>
+              <span class={`now-status now-status--${project.status}`}>{project.status}</span>
+            </div>
+            <p class="now-project-update">{project.update}</p>
+            <span class="now-project-link" aria-hidden="true">
+              <span class="now-project-link-arrow">&rarr;</span>
+              <span class="now-project-link-url">{project.url.replace(/^https?:\/\//, '').replace(/\/$/, '')}</span>
+            </span>
+          </a>
+        </li>
+      ))}
+    </ul>
+
+    <nav class="post-nav" aria-label="Page navigation">
+      <a href="/" class="post-nav-link">&larr; $ cd ~/</a>
+      <a href="/blog/" class="post-nav-link">/blog &rarr;</a>
+    </nav>
+  </main>
+
+  <script>
+    import '../scripts/now';
+  </script>
+</BaseLayout>

--- a/src/scripts/now.ts
+++ b/src/scripts/now.ts
@@ -1,0 +1,35 @@
+type PostHogCaptureProps = Record<string, number | string>;
+type PostHogClient = {
+  capture: (eventName: string, properties?: PostHogCaptureProps) => void;
+};
+
+const posthog = (window as Window & { posthog?: PostHogClient }).posthog;
+const main = document.querySelector<HTMLElement>('main.now-page');
+
+if (posthog && main) {
+  const rows = Array.from(document.querySelectorAll<HTMLAnchorElement>('.now-project-row'));
+  const projectCount = Number(main.dataset.projectCount ?? rows.length);
+
+  posthog.capture('now_viewed', { project_count: projectCount });
+
+  document.addEventListener('click', (ev) => {
+    const link = (ev.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
+    if (!link) return;
+    const href = link.href;
+
+    if (link.matches('.now-project-row')) {
+      const position = rows.indexOf(link) + 1;
+      posthog.capture('now_project_clicked', {
+        name: link.dataset.name ?? '',
+        status: link.dataset.status ?? '',
+        url: href,
+        position
+      });
+      return;
+    }
+
+    if (link.matches('.post-nav-link')) {
+      posthog.capture('now_nav_clicked', { href });
+    }
+  });
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -556,6 +556,41 @@ a.brut-card {
 }
 
 /* ===== Side Projects ===== */
+.side-project-now-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 44px;
+  margin: 0 0 1.25rem;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  text-decoration: none;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.side-project-now-link:hover,
+.side-project-now-link:focus-visible {
+  transform: translate(-2px, -2px);
+  background: var(--color-accent);
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .side-project-now-link {
+    transition: background 0.12s ease;
+  }
+
+  .side-project-now-link:hover,
+  .side-project-now-link:focus-visible {
+    transform: none;
+  }
+}
+
 .side-project-list {
   list-style: none;
   display: grid;

--- a/src/styles/now.css
+++ b/src/styles/now.css
@@ -1,0 +1,211 @@
+/* ===== Now page — Terminal Brutalism ===== */
+
+.now-page {
+  min-height: 100vh;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(1.25rem, 3vw, 2.25rem) var(--section-padding-x)
+    clamp(3.5rem, 9vh, 7rem);
+}
+
+.now-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  margin-bottom: 1.1rem;
+}
+
+.now-header-prompt {
+  color: var(--color-accent);
+  font-weight: 800;
+}
+
+.now-header-cmd {
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.now-rule {
+  border: none;
+  border-top: var(--border-w) solid var(--color-border);
+  margin-bottom: 2.25rem;
+}
+
+.now-title {
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  margin: 0 0 0.75rem;
+  text-wrap: balance;
+}
+
+.now-period {
+  color: var(--color-accent);
+}
+
+.now-updated {
+  font-size: 0.85rem;
+  color: var(--color-ink-muted);
+  margin: 0 0 1.5rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.now-updated-label {
+  font-weight: 700;
+  text-transform: lowercase;
+}
+
+.now-intro {
+  color: var(--color-ink-soft);
+  font-size: 0.95rem;
+  line-height: 1.65;
+  margin: 0 0 2.5rem;
+  max-width: 60ch;
+}
+
+.now-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.now-item {
+  margin: 0;
+}
+
+.now-project-row {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem 1.1rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  color: var(--color-ink);
+  text-decoration: none;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.now-project-row:hover,
+.now-project-row:focus-visible {
+  transform: translate(-2px, -2px);
+  background: var(--color-accent);
+  outline: none;
+}
+
+.now-project-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.now-project-name {
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.now-project-name::before {
+  content: '> ';
+  color: var(--color-accent);
+}
+
+.now-project-row:hover .now-project-name::before,
+.now-project-row:focus-visible .now-project-name::before {
+  color: var(--color-ink);
+}
+
+.now-status {
+  display: inline-block;
+  padding: 0.18rem 0.55rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-bg-alt);
+  color: var(--color-ink);
+}
+
+.now-status--iterating {
+  background: var(--color-surface);
+  border-color: var(--color-accent);
+  color: var(--color-ink);
+}
+
+.now-status--shipping {
+  background: var(--color-accent);
+  color: var(--color-ink);
+}
+
+.now-status--building {
+  background: var(--color-bg-alt);
+  color: var(--color-ink);
+}
+
+.now-status--maintenance {
+  background: transparent;
+  color: var(--color-ink-muted);
+}
+
+.now-project-update {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--color-ink-soft);
+  max-width: 60ch;
+}
+
+.now-project-row:hover .now-project-update,
+.now-project-row:focus-visible .now-project-update {
+  color: var(--color-ink);
+}
+
+.now-project-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--color-ink-muted);
+}
+
+.now-project-link-arrow {
+  color: var(--color-accent);
+  font-weight: 800;
+  transition: transform 0.12s ease;
+}
+
+.now-project-row:hover .now-project-link,
+.now-project-row:focus-visible .now-project-link {
+  color: var(--color-ink);
+}
+
+.now-project-row:hover .now-project-link-arrow {
+  transform: translateX(3px);
+  color: var(--color-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .now-project-row,
+  .now-project-link-arrow {
+    transition: background 0.12s ease;
+  }
+
+  .now-project-row:hover,
+  .now-project-row:focus-visible {
+    transform: none;
+  }
+
+  .now-project-row:hover .now-project-link-arrow {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a `/now` page — the classic [nownownow.com](https://nownownow.com) pattern — showing what I'm actively iterating on. Gives me one public URL to keep current instead of rewriting the home page every time a project moves forward.

### Page
- `src/pages/now.astro` — shell-bar, intro, list of ongoing projects, last-updated stamp.
- `src/styles/now.css` — dedicated list + status-pill styling; reuses `blog.css` for shell-bar and post-nav.
- `src/scripts/now.ts` — PostHog events: `now_viewed` (with `project_count`), `now_project_clicked` (with `name, status, url, position`), `now_nav_clicked`.

### Content (v1)
All four side projects marked `iterating` with a short note each. Status enum (`shipping | building | iterating | maintenance`) is coded up front so adding variants later is a data-only change.

### Discoverability
- Home `/` — new "$ what am i up to now →" button under the Side Projects section header. This is the only deliberate entry point since there's no site-wide nav.
- `@astrojs/sitemap` auto-includes `/now/` — verified in `dist/sitemap-0.xml`.

### SEO
- Title, description, canonical.
- `BreadcrumbList` (Home → Now) and `ItemList` JSON-LD via the BaseLayout head slot.

## Test plan
- [x] `npm run build` succeeds (13 pages)
- [x] `/now/` renders with 4 project rows, each showing name, iterating pill, note
- [x] Sitemap includes `/now/`
- [x] Home page shows the cross-link button above the Side Projects list
- [ ] Visual: spacing + pill color reads cleanly; hover nudges card up-left
- [ ] Keyboard: tab through rows, focus indicator visible, Enter opens external link
- [ ] `prefers-reduced-motion: reduce` — no translate on hover, bg still changes
- [ ] PostHog (with key): `now_viewed` on load, `now_project_clicked` on row click