### PR TITLE
feat(now): add /now page for side projects

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -284,9 +284,9 @@ const sideProjectItemList = {
         <h2 class="section-heading visually-hidden">Side Projects</h2>
         <hr class="section-rule" role="presentation" />
 
-        <a href="/now/" class="side-project-now-link motion-fade">
-          $ what am i up to now <span aria-hidden="true">&rarr;</span>
-        </a>
+        <p class="side-project-intro motion-fade">
+          showing 3 of what i'm up to right now. tap <strong>see all projects</strong> below for the full list.
+        </p>
 
         <ul class="side-project-list" role="list">
           <li>
@@ -316,16 +316,11 @@ const sideProjectItemList = {
               <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
             </a>
           </li>
-          <li>
-            <a href="https://theleonfiles.com" class="side-project-row motion-stagger" target="_blank" rel="noopener noreferrer">
-              <div class="side-project-info">
-                <span class="side-project-name">the-leon-files</span>
-                <p class="side-project-desc">fan site — leon kennedy, resident evil.</p>
-              </div>
-              <span class="side-project-arrow" aria-hidden="true">&rarr;</span>
-            </a>
-          </li>
         </ul>
+
+        <a href="/now/" class="side-project-view-all motion-fade">
+          see all projects <span aria-hidden="true">&rarr;</span>
+        </a>
       </div>
     </section>
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -556,37 +556,56 @@ a.brut-card {
 }
 
 /* ===== Side Projects ===== */
-.side-project-now-link {
+.side-project-intro {
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--color-ink-soft);
+  margin: 0 0 1.25rem;
+  max-width: 60ch;
+}
+
+.side-project-intro strong {
+  color: var(--color-ink);
+  font-weight: 700;
+}
+
+.side-project-view-all {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.4rem;
   min-height: 44px;
-  margin: 0 0 1.25rem;
-  padding: 0.45rem 0.85rem;
-  font-size: 0.9rem;
+  margin-top: 1.25rem;
+  font-size: 0.85rem;
   font-weight: 700;
   color: var(--color-ink);
   text-decoration: none;
+  padding: 0.5rem 0.85rem;
   border: var(--border-w) solid var(--color-border);
   background: var(--color-surface);
   box-shadow: var(--shadow-hard-sm);
   transition: transform 0.12s ease, background 0.12s ease;
 }
 
-.side-project-now-link:hover,
-.side-project-now-link:focus-visible {
+.side-project-view-all::before {
+  content: '$ ';
+  color: var(--color-accent);
+  font-weight: 800;
+}
+
+.side-project-view-all:hover,
+.side-project-view-all:focus-visible {
   transform: translate(-2px, -2px);
   background: var(--color-accent);
   outline: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .side-project-now-link {
+  .side-project-view-all {
     transition: background 0.12s ease;
   }
 
-  .side-project-now-link:hover,
-  .side-project-now-link:focus-visible {
+  .side-project-view-all:hover,
+  .side-project-view-all:focus-visible {
     transform: none;
   }
 }


### PR DESCRIPTION
## Summary
- Add `/now` page listing ongoing side projects with dedicated styles + script
- Trim home preview to 3 projects; intro line frames the preview and a "see all projects" cta points to `/now`
- Drop `the-leon-files` from home preview (still surfaces on `/now`)

## Test plan
- [ ] Visit `/` — preview shows 3 projects, intro line reads correctly, "see all projects" cta links to `/now`
- [ ] Visit `/now/` — all projects render with expected layout and motion
- [ ] Keyboard focus + reduced-motion behavior on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)