### PR TITLE
feat(seo): canonical, schema scoping, per-page lastmod

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,69 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BLOG_DIR = join(__dirname, 'src/content/blog');
+const NOW_UPDATED = '2026-04-22';
+const BUILD_DATE = new Date();
+
+function readFrontmatterDate(file, key) {
+  const src = readFileSync(file, 'utf8');
+  const fm = src.match(/^---([\s\S]*?)---/);
+  if (!fm) return null;
+  const re = new RegExp(`^${key}:\\s*(.+)$`, 'm');
+  const match = fm[1].match(re);
+  if (!match) return null;
+  const raw = match[1].trim().replace(/^['"]|['"]$/g, '');
+  const date = new Date(raw);
+  return Number.isNaN(date.valueOf()) ? null : date;
+}
+
+const blogDates = new Map();
+for (const entry of readdirSync(BLOG_DIR)) {
+  if (!entry.endsWith('.md')) continue;
+  const slug = entry.replace(/\.md$/, '');
+  const full = join(BLOG_DIR, entry);
+  const pub = readFrontmatterDate(full, 'pubDate');
+  const updated = readFrontmatterDate(full, 'updatedDate');
+  blogDates.set(`/blog/${slug}/`, updated ?? pub ?? BUILD_DATE);
+}
+
+const staticDates = new Map([
+  ['/', BUILD_DATE],
+  ['/blog/', BUILD_DATE],
+  ['/now/', new Date(`${NOW_UPDATED}T00:00:00Z`)]
+]);
+
+function resolveLastmod(url) {
+  try {
+    const { pathname } = new URL(url);
+    if (blogDates.has(pathname)) return blogDates.get(pathname);
+    if (staticDates.has(pathname)) return staticDates.get(pathname);
+  } catch {
+    /* ignore */
+  }
+  return BUILD_DATE;
+}
 
 export default defineConfig({
   site: 'https://ralphjonas.com',
+  trailingSlash: 'always',
+  build: {
+    format: 'directory'
+  },
   integrations: [
     sitemap({
       changefreq: 'monthly',
       priority: 0.7,
-      lastmod: new Date()
+      serialize(item) {
+        return {
+          ...item,
+          lastmod: resolveLastmod(item.url).toISOString()
+        };
+      }
     })
   ],
   server: {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,13 +8,21 @@ import '../styles/global.css';
 
 const SITE_URL = 'https://ralphjonas.com';
 const OG_IMAGE = `${SITE_URL}/og.png`;
+const DEFAULT_OG_ALT = 'Ralph Jonas Mungcal — terminal-styled portfolio cover with name set in monospace type.';
 
 const {
   title = 'Ralph Jonas Mungcal — Full-Stack Developer & AI Integration Specialist',
-  description = 'Full-Stack Developer & AI Integration Specialist building scalable platforms, automation systems, and AI-enabled products.'
+  description = 'Full-Stack Developer & AI Integration Specialist building scalable platforms, automation systems, and AI-enabled products.',
+  canonicalURL: canonicalOverride,
+  ogImage = OG_IMAGE,
+  ogImageAlt = DEFAULT_OG_ALT,
+  ogType = 'website',
+  pageType = 'page',
+  breadcrumb,
+  suppressDefaultBreadcrumb = false
 } = Astro.props;
 
-const canonicalURL = new URL(Astro.url.pathname, SITE_URL).toString();
+const canonicalURL = canonicalOverride ?? new URL(Astro.url.pathname, SITE_URL).toString();
 const currentYear = new Date().getFullYear();
 const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
 
@@ -41,29 +49,43 @@ const person = {
     'https://www.linkedin.com/in/ralphjonasmungcal',
     'https://www.upwork.com/o/profiles/users/_~01108375a06953763f/',
     'https://ralphdev.bearblog.dev/',
-    'https://twitter.com/ItsRalphSenpai'
+    'https://x.com/ralphsenpaidev'
   ]
 };
 
-const profilePage = {
-  '@context': 'https://schema.org',
-  '@type': 'ProfilePage',
-  '@id': `${canonicalURL}#profilepage`,
-  url: canonicalURL,
-  name: title,
-  description,
-  inLanguage: 'en',
-  dateCreated: '2019-01-17',
-  dateModified: new Date().toISOString(),
-  mainEntity: person,
-  about: person,
-  copyrightYear: currentYear,
-  copyrightHolder: person,
-  publisher: person,
-  image: { '@type': 'ImageObject', url: OG_IMAGE, width: 1200, height: 630 }
-};
+const profilePage = pageType === 'profile'
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'ProfilePage',
+      '@id': `${canonicalURL}#profilepage`,
+      url: canonicalURL,
+      name: title,
+      description,
+      inLanguage: 'en',
+      dateCreated: '2019-01-17',
+      dateModified: new Date().toISOString(),
+      mainEntity: person,
+      about: person,
+      copyrightYear: currentYear,
+      copyrightHolder: person,
+      publisher: person,
+      image: { '@type': 'ImageObject', url: OG_IMAGE, width: 1200, height: 630 }
+    }
+  : {
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      '@id': `${canonicalURL}#webpage`,
+      url: canonicalURL,
+      name: title,
+      description,
+      inLanguage: 'en',
+      isPartOf: { '@id': `${SITE_URL}/#website` },
+      author: person,
+      publisher: person,
+      primaryImageOfPage: { '@type': 'ImageObject', url: ogImage }
+    };
 
-const breadcrumb = {
+const defaultBreadcrumb = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
@@ -75,6 +97,8 @@ const breadcrumb = {
     }
   ]
 };
+
+const resolvedBreadcrumb = breadcrumb ?? (suppressDefaultBreadcrumb ? null : defaultBreadcrumb);
 ---
 <!doctype html>
 <html lang="en">
@@ -109,28 +133,30 @@ const breadcrumb = {
     <meta property="og:locale" content="en_US" />
     <meta property="og:site_name" content="Ralph Jonas Mungcal" />
     <meta property="og:title" content={title} />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content={OG_IMAGE} />
-    <meta property="og:image:alt" content={description} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:image:alt" content={ogImageAlt} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@ItsRalphSenpai" />
-    <meta name="twitter:site" content="@ItsRalphSenpai" />
+    <meta name="twitter:creator" content="@ralphsenpaidev" />
+    <meta name="twitter:site" content="@ralphsenpaidev" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content={OG_IMAGE} />
-    <meta name="twitter:image:alt" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content={ogImageAlt} />
 
     <meta name="theme-color" content="#fdfbf0" />
     <link rel="manifest" href="/manifest.webmanifest" crossorigin="anonymous" />
 
     <script is:inline type="application/ld+json" set:html={JSON.stringify(profilePage)}></script>
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumb)}></script>
+    {resolvedBreadcrumb && (
+      <script is:inline type="application/ld+json" set:html={JSON.stringify(resolvedBreadcrumb)}></script>
+    )}
 
     <slot name="head" />
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,7 +1,13 @@
 ---
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { getPublishedPosts, formatPubDateLong, getRelatedPosts } from '../../utils/blog';
+import {
+  getPublishedPosts,
+  formatPubDateLong,
+  getRelatedPosts,
+  getWordCount,
+  getReadingTimeMinutes
+} from '../../utils/blog';
 import '../../styles/blog.css';
 
 export async function getStaticPaths() {
@@ -24,6 +30,9 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
 const canonicalURL = post.data.canonical
   ?? `https://ralphjonas.com/blog/${post.id}/`;
 
+const wordCount = getWordCount(post.body);
+const readingTime = getReadingTimeMinutes(wordCount);
+
 const blogPosting = {
   '@context': 'https://schema.org',
   '@type': 'BlogPosting',
@@ -37,7 +46,9 @@ const blogPosting = {
   publisher: { '@id': 'https://ralphjonas.com/#person' },
   mainEntityOfPage: canonicalURL,
   image: 'https://ralphjonas.com/og.png',
-  inLanguage: 'en'
+  inLanguage: 'en',
+  wordCount,
+  timeRequired: `PT${readingTime}M`
 };
 
 const breadcrumb = {
@@ -51,11 +62,15 @@ const breadcrumb = {
 };
 ---
 
-<BaseLayout title={`${post.data.title} — Ralph Jonas Mungcal`} description={post.data.description}>
+<BaseLayout
+  title={`${post.data.title} — Ralph Jonas Mungcal`}
+  description={post.data.description}
+  canonicalURL={canonicalURL}
+  ogType="article"
+  breadcrumb={breadcrumb}
+>
   <Fragment slot="head">
     <script is:inline type="application/ld+json" set:html={JSON.stringify(blogPosting)}></script>
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumb)}></script>
-    {post.data.canonical && <link rel="canonical" href={post.data.canonical} />}
   </Fragment>
 
   <main
@@ -89,6 +104,9 @@ const breadcrumb = {
         {formatPubDateLong(post.data.pubDate)}
         {post.data.updatedDate && (
           <> &middot; updated {formatPubDateLong(post.data.updatedDate)}</>
+        )}
+        {readingTime > 0 && (
+          <> &middot; {readingTime} min read</>
         )}
       </time>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,10 +7,27 @@ const posts = await getPublishedPosts();
 
 const title = 'Writing — Ralph Jonas Mungcal';
 const description = 'Notes on software engineering, AI integration, career, and craft by Ralph Jonas Mungcal.';
+const canonicalURL = 'https://ralphjonas.com/blog/';
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
+    { '@type': 'ListItem', position: 2, name: 'Writing', item: canonicalURL }
+  ]
+};
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout
+  title={title}
+  description={description}
+  canonicalURL={canonicalURL}
+  breadcrumb={breadcrumb}
+>
   <main class="blog-page">
+    <h1 class="visually-hidden">Writing by Ralph Jonas Mungcal</h1>
+
     <div class="blog-shell-bar" role="banner">
       <div class="blog-shell-bar-dots" aria-hidden="true">
         <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
@@ -37,13 +54,15 @@ const description = 'Notes on software engineering, AI integration, career, and 
       <ul class="blog-list" role="list">
         {posts.map((post) => (
           <li class="blog-list-item">
-            <a href={`/blog/${post.id}/`} class="blog-list-link">
-              <time class="blog-list-date" datetime={post.data.pubDate.toISOString()}>
-                {formatPubDate(post.data.pubDate)}
-              </time>
-              <span class="blog-list-title">{post.data.title}</span>
-              <span class="blog-list-arrow" aria-hidden="true">&rarr;</span>
-            </a>
+            <article>
+              <a href={`/blog/${post.id}/`} class="blog-list-link">
+                <time class="blog-list-date" datetime={post.data.pubDate.toISOString()}>
+                  {formatPubDate(post.data.pubDate)}
+                </time>
+                <span class="blog-list-title">{post.data.title}</span>
+                <span class="blog-list-arrow" aria-hidden="true">&rarr;</span>
+              </a>
+            </article>
           </li>
         ))}
       </ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,7 +56,7 @@ const sideProjectItemList = {
     '@type': 'ListItem',
     position: index + 1,
     item: {
-      '@type': 'WebSite',
+      '@type': 'CreativeWork',
       name: project.name,
       url: project.url,
       description: project.description,
@@ -66,7 +66,7 @@ const sideProjectItemList = {
 };
 ---
 
-<BaseLayout>
+<BaseLayout pageType="profile">
   <Fragment slot="head">
     <script is:inline type="application/ld+json" set:html={JSON.stringify(projectItemList)}></script>
     <script is:inline type="application/ld+json" set:html={JSON.stringify(sideProjectItemList)}></script>
@@ -97,13 +97,14 @@ const sideProjectItemList = {
           <span style="color: var(--color-ink-muted);">--verbose</span>
         </div>
 
-        <h1 class="hero-name" aria-label="Ralph Jonas">
-          <span class="hero-name-line">
+        <h1 class="hero-name">
+          <span class="visually-hidden">Ralph Jonas Mungcal — Full-Stack Developer & AI Integration Specialist</span>
+          <span class="hero-name-line" aria-hidden="true">
             {'Ralph'.split('').map(letter => (
               <span class="hero-name-letter motion-letter">{letter}</span>
             ))}
           </span>
-          <span class="hero-name-line">
+          <span class="hero-name-line" aria-hidden="true">
             {'Jonas'.split('').map(letter => (
               <span class="hero-name-letter motion-letter">{letter}</span>
             ))}

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -40,7 +40,7 @@ const nowItemList = {
     '@type': 'ListItem',
     position: index + 1,
     item: {
-      '@type': 'WebSite',
+      '@type': 'CreativeWork',
       name: project.name,
       url: project.url,
       description: project.update,
@@ -56,9 +56,13 @@ const formattedUpdated = new Date(`${NOW_UPDATED}T00:00:00Z`).toLocaleDateString
 });
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout
+  title={title}
+  description={description}
+  canonicalURL={canonicalURL}
+  breadcrumb={breadcrumb}
+>
   <Fragment slot="head">
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(breadcrumb)}></script>
     <script is:inline type="application/ld+json" set:html={JSON.stringify(nowItemList)}></script>
   </Fragment>
 

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -25,6 +25,23 @@ export function toIsoDate(date: Date): string {
   return date.toISOString().split('T')[0];
 }
 
+export function getWordCount(body: string | undefined): number {
+  if (!body) return 0;
+  const text = body
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[#>*_~\-]+/g, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  const words = text.match(/\b[\w'-]+\b/g);
+  return words ? words.length : 0;
+}
+
+export function getReadingTimeMinutes(wordCount: number): number {
+  return Math.max(1, Math.round(wordCount / 225));
+}
+
 export function getRelatedPosts(
   current: BlogEntry,
   all: BlogEntry[],


### PR DESCRIPTION
## Summary
- Fix duplicate canonicals on blog posts; enforce deterministic URLs via `trailingSlash: 'always'` + `build.format: 'directory'`
- Scope `ProfilePage` to homepage; emit `WebPage` elsewhere; gate default `BreadcrumbList` behind a prop so pages that emit their own stop duplicating
- Normalize X identity to `@ralphsenpaidev` across `sameAs`, `twitter:creator`, `twitter:site`
- Set `og:type="article"` for blog posts; dedicated OG image alt
- Embed keyword phrase in homepage `h1` via `visually-hidden` child; add `visually-hidden` `h1` to blog index
- Add `wordCount` + `timeRequired` to `BlogPosting` JSON-LD; render reading time next to post date
- Switch `CreativeWork` for side-project and `/now` `ItemList` children (was `WebSite`)
- Wire sitemap `serialize` hook to emit per-URL `lastmod` from frontmatter (blog) and `NOW_UPDATED` (/now)
- Wrap blog list rows in `<article>`

## Why
Post-audit fixes covering the Critical/High/Medium items: duplicate tags, trailing-slash drift, weak H1 signal, missing reading-time metadata, handle mismatch, schema-type mismatches, identical sitemap `lastmod` for all URLs.

## Test plan
- [ ] View-source of `/` — one `<link rel="canonical">`, `@type: ProfilePage`, `<h1>` contains the keyword phrase via visually-hidden child
- [ ] View-source of `/blog/gcp-secrets/` — one canonical, `og:type: article`, `@type: WebPage` + single `BreadcrumbList`, `BlogPosting` contains `wordCount` + `timeRequired`
- [ ] `/sitemap-0.xml` — per-URL `lastmod` (blog uses `pubDate`, `/now` uses `2026-04-22`)
- [ ] Grep built HTML for `ItsRalphSenpai` → no matches; `ralphsenpaidev` appears in `sameAs`, `twitter:creator`, `twitter:site`
- [ ] Rendered post page shows "… · N min read" next to date
- [ ] `/blog/` shows no visible change; source now has `<h1 class="visually-hidden">` and `<article>` wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)