### PR TITLE
feat(blog): add claude skills workflow post

### DIFF
--- a/src/content/blog/claude-skills-that-changed-my-workflow.md
+++ b/src/content/blog/claude-skills-that-changed-my-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Skills That Changed My Workflow
-description: Skills turn Claude from a general chatbot into a domain-specific tool. The document, engineering, data, and productivity skills I actually use daily — and why they pay off.
+description: The Claude skills I actually use daily — document, engineering, data, and productivity — and why they cut the prompting tax.
 pubDate: 2026-04-22
 tags:
   - ai
@@ -96,6 +96,23 @@ It turns Claude from "helpful stranger" into "coworker who's been here a while."
 You can build custom skills — define the instructions, test them with evals, and optimize the triggering. If you have a repeating workflow that Claude handles but needs specific prompting every time, you package it as a skill once and never think about it again.
 
 I've used this to create project-specific skills that encode our team's conventions, coding standards, and documentation formats.
+
+A skill is just a markdown file with frontmatter describing when to trigger it:
+
+```markdown
+---
+name: pr-review
+description: Use when reviewing pull requests — enforces our team's checklist for security, tests, and migration safety.
+---
+
+When reviewing a PR, check in order:
+1. Does the change include tests? If no, flag it.
+2. Any raw SQL? Check for parameterization.
+3. Schema migrations? Verify they're reversible.
+4. Secrets or env vars in the diff? Reject immediately.
+```
+
+That's the whole thing. Claude picks it up, follows it, and you stop re-typing the same checklist every review.
 
 ---
 

--- a/src/content/blog/claude-skills-that-changed-my-workflow.md
+++ b/src/content/blog/claude-skills-that-changed-my-workflow.md
@@ -1,0 +1,124 @@
+---
+title: Claude Skills That Changed My Workflow
+description: Skills turn Claude from a general chatbot into a domain-specific tool. The document, engineering, data, and productivity skills I actually use daily — and why they pay off.
+pubDate: 2026-04-22
+tags:
+  - ai
+  - developer-workflow
+  - productivity
+---
+
+Most people use Claude like a chatbot — ask a question, get an answer. That's fine, but it leaves a lot on the table.
+
+The real shift for me was Claude Skills. Skills are specialized instruction sets that turn Claude from a general-purpose assistant into a domain-specific tool. Instead of prompting from scratch every time, you load a skill and Claude already knows the format, the constraints, and the best practices for that task.
+
+Here are the ones that actually changed how I work.
+
+---
+
+## Document Generation Skills
+
+### DOCX, PPTX, XLSX, PDF
+
+Before skills, getting Claude to produce a properly formatted Word doc or spreadsheet was a multi-round fight. You'd describe what you wanted, get something half-right, then spend 20 minutes fixing formatting.
+
+With the document skills, Claude knows how to use python-docx, python-pptx, openpyxl, and PDF libraries correctly out of the gate. It follows best practices for structure, styling, and layout without you having to specify every detail.
+
+**How I use them:**
+
+- Generate technical reports as `.docx` with proper headings, tables of contents, and page numbers
+- Build slide decks from outlines — consistent layout, no manual resizing
+- Create spreadsheets with formulas, conditional formatting, and charts
+- Fill PDF forms and merge documents programmatically
+
+**The before/after:** What used to be "ask Claude → get broken output → fix manually → give up and do it in Word" is now "ask Claude → get a production-ready file." The skill handles the library quirks so I don't have to.
+
+---
+
+## Engineering Skills
+
+This is the set I use daily.
+
+### Code Review
+
+I feed it a diff or a code snippet and it checks for bugs, security vulnerabilities, performance issues, and maintainability. It's not a replacement for a human reviewer, but it catches the mechanical stuff — missing error handling, SQL injection vectors, N+1 queries — before the PR even goes up.
+
+### System Design
+
+When I'm architecting a new service or API, this skill structures the thinking: service boundaries, data modeling, API contracts, scaling considerations. It forces the right questions early instead of discovering them mid-implementation.
+
+### Documentation
+
+The hardest part of writing docs is starting. This skill generates structured technical docs — API references, runbooks, onboarding guides — from minimal input. I provide the what, it handles the how-to-format-it.
+
+### Debugging
+
+Structured debugging sessions: reproduce → isolate → diagnose → fix. Instead of dumping an error into chat and hoping for the best, this skill walks through a systematic process. It's especially useful for distributed system issues where the root cause isn't in the layer that's screaming.
+
+---
+
+## Data Skills
+
+I don't do data engineering full-time, but I touch data regularly — analytics queries, one-off analysis, building dashboards for internal tools.
+
+### SQL Queries
+
+Handles dialect differences between PostgreSQL, BigQuery, Snowflake, etc. I describe what I need, it writes optimized SQL with proper CTEs and window functions. Saves me from Googling dialect-specific syntax every time.
+
+### Data Exploration & Visualization
+
+Profile a dataset, find nulls and outliers, understand distributions — then generate clean charts with matplotlib or plotly. What used to be a Jupyter notebook rabbit hole is now a focused 10-minute workflow.
+
+### Interactive Dashboards
+
+Self-contained HTML dashboards with Chart.js, filters, and professional styling. No server required. I've used this to build internal reporting tools that I can just share as a file.
+
+---
+
+## Productivity Skills
+
+### Task Management
+
+A shared `TASKS.md` file that Claude reads and writes to. Simple, but it means Claude has context on what I'm working on across sessions. No more re-explaining my current priorities.
+
+### Memory Management
+
+This is the underrated one. Claude builds a knowledge base of my shorthand, acronyms, project names, and internal language. Over time it understands "the payment service" means a specific thing in my context, not a generic concept.
+
+It turns Claude from "helpful stranger" into "coworker who's been here a while."
+
+---
+
+## The Skill That Makes Skills
+
+### Skill Creator
+
+You can build custom skills — define the instructions, test them with evals, and optimize the triggering. If you have a repeating workflow that Claude handles but needs specific prompting every time, you package it as a skill once and never think about it again.
+
+I've used this to create project-specific skills that encode our team's conventions, coding standards, and documentation formats.
+
+---
+
+## Why This Matters
+
+The pattern across all of these: **skills eliminate the prompting tax.**
+
+Every time you open Claude and re-explain your formatting preferences, your tech stack, your documentation style — that's a tax. Skills pay it once. After that, Claude just knows.
+
+The compound effect is significant. Each skill saves a few minutes per use. Across a full workday touching code, docs, data, and project management — that's easily an hour reclaimed. Not from doing things faster, but from not doing the setup work at all.
+
+---
+
+## Getting Started
+
+If you're new to skills:
+
+1. Start with the document skills (docx, xlsx, pdf). The ROI is immediate and obvious.
+2. Add the engineering skills if you write code. Code review and debugging alone are worth it.
+3. Build a custom skill for your most repeated workflow. That's where the real leverage kicks in.
+
+Don't try to adopt everything at once. Pick the skill that matches your biggest friction point and use it for a week. You'll feel the difference.
+
+---
+
+*Written with the help of Claude and several of the skills mentioned above. Meta? Maybe. Effective? Definitely.*


### PR DESCRIPTION
## Summary
- Adds new blog post covering Claude Skills (document, engineering, data, productivity)
- pubDate 2026-04-22, tags: ai, developer-workflow, productivity
- Stripped Obsidian `[[wikilinks]]` to plain text (site doesn't process them)

## Test plan
- [ ] Post appears in blog index
- [ ] Frontmatter parses, tags link correctly
- [ ] Sitemap includes new URL via per-page lastmod