### PR TITLE
Show full blog publication dates

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -718,7 +718,7 @@ a.brut-card {
   font-weight: 600;
   color: var(--color-accent);
   flex-shrink: 0;
-  min-width: 7ch;
+  min-width: 12ch;
   font-variant-numeric: tabular-nums;
 }
 

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -10,7 +10,11 @@ export async function getPublishedPosts(): Promise<BlogEntry[]> {
 }
 
 export function formatPubDate(date: Date): string {
-  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}`;
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
 }
 
 export function formatPubDateLong(date: Date): string {


### PR DESCRIPTION
## Summary
- include the day in compact blog publication dates
- widen the home writing-list date column for the longer YYYY.MM.DD format

## Verification
- npm run build passed
- npm run check currently fails on pre-existing Astro type errors in src/pages/blog/[...slug].astro