### PR TITLE
fix(seo): remove hardcoded dateCreated from ProfilePage schema

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -62,7 +62,6 @@ const profilePage = pageType === 'profile'
       name: title,
       description,
       inLanguage: 'en',
-      dateCreated: '2019-01-17',
       dateModified: new Date().toISOString(),
       mainEntity: person,
       about: person,


### PR DESCRIPTION
## Summary
- Removed hardcoded `dateCreated: '2019-01-17'` from the ProfilePage JSON-LD in `BaseLayout.astro`
- Google was surfacing that date in search snippets ("January 17, 2019 - Full-Stack Developer...")
- `dateModified` and sitemap `lastmod` remain to signal freshness

## Test plan
- [ ] Build site and inspect ProfilePage JSON-LD on home page — confirm no `dateCreated`
- [ ] Validate JSON-LD via Schema.org validator / Google Rich Results test
- [ ] After deploy, request re-index in Google Search Console