### PR TITLE
fix(seo): declare larger favicons for Google search results

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -110,6 +110,8 @@ const resolvedBreadcrumb = breadcrumb ?? (suppressDefaultBreadcrumb ? null : def
     <title>{title}</title>
 
     <link rel="apple-touch-icon" href="/favicons/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/favicons/icon-512.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/favicons/icon-192.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
     <link rel="shortcut icon" href="/favicon.ico" />


### PR DESCRIPTION
## Summary
- Added `<link rel=\"icon\">` entries for `icon-192.png` and `icon-512.png` in `BaseLayout.astro`
- Google requires favicons of at least 48×48 to display in SERP, otherwise falls back to the default globe icon
- The PWA icons already existed in `public/favicons/` — just needed to be referenced in `<head>`

## Test plan
- [ ] Build site, verify all five `<link rel=\"icon\">` tags render in `<head>`
- [ ] Run Google Rich Results Test on the homepage
- [ ] After deploy, request re-index in Google Search Console — favicon refresh can take days/weeks