### PR TITLE
feat(home): Add ai-meeting-editor to featured projects

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,8 @@ const featuredProjects = [
   { name: 'billing-payment-platform', stack: ['Node.js', 'TypeScript', 'GCP', 'Event-driven'], description: 'Multi-gateway payment orchestration with unified subscription billing, dunning, and smart retry.' },
   { name: 'airline-data-bots', stack: ['TypeScript', 'Puppeteer', 'BullMQ'], description: 'Automated scrapers collecting flight availability data from multiple airline sources on schedule.' },
   { name: 'remote-mcp-server', stack: ['TypeScript', 'Node.js', 'Docker'], description: 'Model Context Protocol server over URL — AI assistants hit custom tools via SSE transport.' },
-  { name: 'home-infra-lab', stack: ['Docker', 'Linux', 'TrueNAS', 'Tailscale'], description: 'Multi-node self-hosted services — NAS, media, workflow automation, monitoring dashboards.' }
+  { name: 'home-infra-lab', stack: ['Docker', 'Linux', 'TrueNAS', 'Tailscale'], description: 'Multi-node self-hosted services — NAS, media, workflow automation, monitoring dashboards.' },
+  { name: 'ai-meeting-editor', stack: ['Python', 'Whisper', 'Deepgram', 'FFmpeg', 'PyTorch', 'AWS'], description: 'AI-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.' }
 ];
 
 const sideProjects = [
@@ -227,6 +228,11 @@ const sideProjectItemList = {
             <span class="project-name">home-infra-lab</span>
             <span class="project-tech">docker · linux · truenas · tailscale</span>
             <p class="project-desc">multi-node self-hosted services — nas, media, workflow automation, monitoring dashboards.</p>
+          </li>
+          <li class="project-row motion-stagger">
+            <span class="project-name">ai-meeting-editor</span>
+            <span class="project-tech">python · whisper · deepgram · ffmpeg · pytorch · aws</span>
+            <p class="project-desc">ai-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.</p>
           </li>
         </ul>
 


### PR DESCRIPTION
## Summary
- Adds `ai-meeting-editor` as a new featured project after `home-infra-lab`
- AI-powered meeting editor that auto-detects discussion start/end to trim dead air
- Stack: python · whisper · deepgram · ffmpeg · pytorch · aws

## Test plan
- [ ] Verify project renders in featured list on homepage
- [ ] Verify structured-data JSON-LD includes new entry