### PR TITLE
feat(seo): Add WebSite schema, tag pages, per-post OG images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .astro
 dist
+public/og/

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
+    "prebuild": "node scripts/generate-blog-og.mjs",
     "build": "astro build",
     "check": "astro check",
     "preview": "astro preview",
     "generate:og": "node scripts/generate-og.mjs",
+    "generate:blog-og": "node scripts/generate-blog-og.mjs",
     "generate:icons": "node scripts/generate-icons.mjs"
   },
   "dependencies": {

--- a/scripts/generate-blog-og.mjs
+++ b/scripts/generate-blog-og.mjs
@@ -1,0 +1,154 @@
+import sharp from 'sharp';
+import { readdirSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BLOG_DIR = resolve(__dirname, '../src/content/blog');
+const OUT_DIR = resolve(__dirname, '../public/og');
+
+if (!existsSync(OUT_DIR)) {
+  mkdirSync(OUT_DIR, { recursive: true });
+}
+
+function escapeXml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function readFrontmatter(file) {
+  const src = readFileSync(file, 'utf8');
+  const match = src.match(/^---([\s\S]*?)---/);
+  if (!match) return {};
+  const data = {};
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^([a-zA-Z]+):\s*(.+)$/);
+    if (!m) continue;
+    const [, key, raw] = m;
+    data[key] = raw.trim().replace(/^['"]|['"]$/g, '');
+  }
+  return data;
+}
+
+function wrapLines(title, maxChars, maxLines) {
+  const words = title.split(/\s+/);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length > maxChars && current) {
+      lines.push(current);
+      current = word;
+      if (lines.length === maxLines - 1) break;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current && lines.length < maxLines) {
+    lines.push(current);
+  }
+  if (lines.length === maxLines && words.join(' ').length > lines.join(' ').length) {
+    const last = lines[lines.length - 1];
+    lines[lines.length - 1] = last.length > maxChars - 1
+      ? `${last.slice(0, maxChars - 1)}…`
+      : `${last}…`;
+  }
+  return lines;
+}
+
+function buildSvg({ title, tags }) {
+  const safeTitle = escapeXml(title);
+  const lines = wrapLines(safeTitle, 26, 3);
+  const titleY = 290;
+  const lineHeight = 78;
+  const tagItems = tags.slice(0, 4).map((t) => `#${t}`);
+
+  const titleTspans = lines
+    .map((line, i) => {
+      const cursor = i === lines.length - 1
+        ? `${line}<tspan fill="#ff6a1a">_</tspan>`
+        : line;
+      return `<tspan x="90" y="${titleY + i * lineHeight}">${cursor}</tspan>`;
+    })
+    .join('');
+
+  let tagX = 90;
+  const tagSvg = tagItems
+    .map((tag) => {
+      const width = Math.max(80, tag.length * 14 + 30);
+      const block = `
+        <rect x="${tagX}" y="500" width="${width}" height="44" fill="#fdfbf0" stroke="#0a0a0a" stroke-width="2"/>
+        <text x="${tagX + 15}" y="529" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="20" font-weight="600" fill="#0a0a0a">${escapeXml(tag)}</text>`;
+      tagX += width + 14;
+      return block;
+    })
+    .join('');
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#f5f1dc" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="630" fill="#fdfbf0"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <rect x="40" y="40" width="1120" height="550" fill="#fffdf3" stroke="#0a0a0a" stroke-width="3"/>
+  <rect x="46" y="46" width="1120" height="550" fill="none" stroke="#0a0a0a" stroke-width="3" opacity="0.08"/>
+
+  <rect x="40" y="40" width="1120" height="52" fill="#f5f1dc" stroke="#0a0a0a" stroke-width="3"/>
+  <circle cx="72" cy="66" r="7" fill="#ff6a1a"/>
+  <circle cx="96" cy="66" r="7" fill="#0a0a0a" fill-opacity="0.15"/>
+  <circle cx="120" cy="66" r="7" fill="#0a0a0a" fill-opacity="0.15"/>
+  <text x="160" y="73" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="18" font-weight="600" fill="#3a3a3a">ralph@jonas:~/writing — post.md</text>
+
+  <text x="90" y="180" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="22" fill="#6b6b66">
+    <tspan fill="#ff6a1a" font-weight="700">$</tspan> cat post.md
+  </text>
+
+  <text font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="64" font-weight="800" fill="#0a0a0a" letter-spacing="-2">
+    ${titleTspans}
+  </text>
+
+  ${tagSvg}
+
+  <line x1="90" y1="585" x2="1110" y2="585" stroke="#0a0a0a" stroke-width="2"/>
+  <text x="90" y="568" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="20" font-weight="600" fill="#0a0a0a">ralphjonas.com/blog</text>
+</svg>
+`;
+}
+
+function parseTags(raw) {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return trimmed
+      .slice(1, -1)
+      .split(',')
+      .map((t) => t.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+const entries = readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'));
+let count = 0;
+for (const entry of entries) {
+  const slug = entry.replace(/\.md$/, '');
+  const fm = readFrontmatter(join(BLOG_DIR, entry));
+  if (fm.draft === 'true') continue;
+  const title = fm.title ?? slug;
+  const tags = parseTags(fm.tags);
+  const svg = buildSvg({ title, tags });
+  const out = join(OUT_DIR, `${slug}.png`);
+  await sharp(Buffer.from(svg)).png({ compressionLevel: 9 }).toFile(out);
+  count += 1;
+}
+
+console.log(`generated ${count} blog OG images → ${OUT_DIR}`);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,12 +19,15 @@ const {
   ogType = 'website',
   pageType = 'page',
   breadcrumb,
-  suppressDefaultBreadcrumb = false
+  suppressDefaultBreadcrumb = false,
+  dateModified,
+  noindex = false
 } = Astro.props;
 
 const canonicalURL = canonicalOverride ?? new URL(Astro.url.pathname, SITE_URL).toString();
 const currentYear = new Date().getFullYear();
 const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
+const robotsContent = noindex ? 'noindex, follow' : 'index, follow, max-image-preview:large';
 
 const person = {
   '@type': 'Person',
@@ -34,7 +37,7 @@ const person = {
   url: SITE_URL,
   image: OG_IMAGE,
   jobTitle: 'Full-Stack Developer & AI Integration Specialist',
-  description,
+  description: 'Full-Stack Developer & AI Integration Specialist building scalable platforms, automation systems, and AI-enabled products.',
   nationality: { '@type': 'Country', name: 'Philippines' },
   knowsAbout: [
     'Full-Stack Development',
@@ -53,35 +56,67 @@ const person = {
   ]
 };
 
+const website = {
+  '@type': 'WebSite',
+  '@id': `${SITE_URL}/#website`,
+  url: SITE_URL,
+  name: 'Ralph Jonas Mungcal',
+  description: 'Full-Stack Developer & AI Integration Specialist — portfolio, writing, and projects.',
+  inLanguage: 'en',
+  publisher: { '@id': `${SITE_URL}/#person` },
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${SITE_URL}/blog/?q={search_term_string}`
+    },
+    'query-input': 'required name=search_term_string'
+  }
+};
+
 const profilePage = pageType === 'profile'
   ? {
       '@context': 'https://schema.org',
-      '@type': 'ProfilePage',
-      '@id': `${canonicalURL}#profilepage`,
-      url: canonicalURL,
-      name: title,
-      description,
-      inLanguage: 'en',
-      dateModified: new Date().toISOString(),
-      mainEntity: person,
-      about: person,
-      copyrightYear: currentYear,
-      copyrightHolder: person,
-      publisher: person,
-      image: { '@type': 'ImageObject', url: OG_IMAGE, width: 1200, height: 630 }
+      '@graph': [
+        person,
+        website,
+        {
+          '@type': 'ProfilePage',
+          '@id': `${canonicalURL}#profilepage`,
+          url: canonicalURL,
+          name: title,
+          description,
+          inLanguage: 'en',
+          isPartOf: { '@id': `${SITE_URL}/#website` },
+          ...(dateModified ? { dateModified } : {}),
+          mainEntity: { '@id': `${SITE_URL}/#person` },
+          about: { '@id': `${SITE_URL}/#person` },
+          copyrightYear: currentYear,
+          copyrightHolder: { '@id': `${SITE_URL}/#person` },
+          publisher: { '@id': `${SITE_URL}/#person` },
+          image: { '@type': 'ImageObject', url: OG_IMAGE, width: 1200, height: 630 }
+        }
+      ]
     }
   : {
       '@context': 'https://schema.org',
-      '@type': 'WebPage',
-      '@id': `${canonicalURL}#webpage`,
-      url: canonicalURL,
-      name: title,
-      description,
-      inLanguage: 'en',
-      isPartOf: { '@id': `${SITE_URL}/#website` },
-      author: person,
-      publisher: person,
-      primaryImageOfPage: { '@type': 'ImageObject', url: ogImage }
+      '@graph': [
+        person,
+        website,
+        {
+          '@type': 'WebPage',
+          '@id': `${canonicalURL}#webpage`,
+          url: canonicalURL,
+          name: title,
+          description,
+          inLanguage: 'en',
+          isPartOf: { '@id': `${SITE_URL}/#website` },
+          ...(dateModified ? { dateModified } : {}),
+          author: { '@id': `${SITE_URL}/#person` },
+          publisher: { '@id': `${SITE_URL}/#person` },
+          primaryImageOfPage: { '@type': 'ImageObject', url: ogImage }
+        }
+      ]
     };
 
 const defaultBreadcrumb = {
@@ -129,7 +164,7 @@ const resolvedBreadcrumb = breadcrumb ?? (suppressDefaultBreadcrumb ? null : def
     <meta name="msapplication-config" content="/browserconfig.xml" />
     <meta name="description" content={description} />
     <meta name="author" content="Ralph Jonas Mungcal" />
-    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="robots" content={robotsContent} />
 
     <meta property="og:locale" content="en_US" />
     <meta property="og:site_name" content="Ralph Jonas Mungcal" />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="404 | ralph jonas mungcal">
+<BaseLayout title="404 | ralph jonas mungcal" noindex={true}>
   <main class="not-found">
     <div class="not-found__inner">
       <div class="not-found__shell" aria-hidden="true">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -6,7 +6,8 @@ import {
   formatPubDateLong,
   getRelatedPosts,
   getWordCount,
-  getReadingTimeMinutes
+  getReadingTimeMinutes,
+  tagToSlug
 } from '../../utils/blog';
 import '../../styles/blog.css';
 
@@ -32,6 +33,9 @@ const canonicalURL = post.data.canonical
 
 const wordCount = getWordCount(post.body);
 const readingTime = getReadingTimeMinutes(wordCount);
+const dateModified = (post.data.updatedDate ?? post.data.pubDate).toISOString();
+const ogImage = `https://ralphjonas.com/og/${post.id}.png`;
+const ogImageAlt = `${post.data.title} — article cover by Ralph Jonas Mungcal`;
 
 const blogPosting = {
   '@context': 'https://schema.org',
@@ -40,15 +44,16 @@ const blogPosting = {
   headline: post.data.title,
   description: post.data.description,
   datePublished: post.data.pubDate.toISOString(),
-  dateModified: (post.data.updatedDate ?? post.data.pubDate).toISOString(),
+  dateModified,
   keywords: post.data.tags.join(', '),
   author: { '@id': 'https://ralphjonas.com/#person' },
   publisher: { '@id': 'https://ralphjonas.com/#person' },
   mainEntityOfPage: canonicalURL,
-  image: 'https://ralphjonas.com/og.png',
+  image: ogImage,
   inLanguage: 'en',
   wordCount,
-  timeRequired: `PT${readingTime}M`
+  timeRequired: `PT${readingTime}M`,
+  isPartOf: { '@id': 'https://ralphjonas.com/#website' }
 };
 
 const breadcrumb = {
@@ -67,6 +72,9 @@ const breadcrumb = {
   description={post.data.description}
   canonicalURL={canonicalURL}
   ogType="article"
+  ogImage={ogImage}
+  ogImageAlt={ogImageAlt}
+  dateModified={dateModified}
   breadcrumb={breadcrumb}
 >
   <Fragment slot="head">
@@ -117,7 +125,7 @@ const breadcrumb = {
       {post.data.tags.length > 0 && (
         <div class="post-tags" aria-label="Tags">
           {post.data.tags.map((tag) => (
-            <span class="post-tag">#{tag}</span>
+            <a class="post-tag" href={`/blog/tags/${tagToSlug(tag)}/`}>#{tag}</a>
           ))}
         </div>
       )}

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,126 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import {
+  getPublishedPosts,
+  formatPubDate,
+  tagToSlug,
+  getAllTags
+} from '../../../utils/blog';
+import '../../../styles/blog.css';
+
+export async function getStaticPaths() {
+  const posts = await getPublishedPosts();
+  const map = new Map<string, { tag: string; posts: typeof posts }>();
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const slug = tagToSlug(tag);
+      const bucket = map.get(slug);
+      if (bucket) {
+        bucket.posts.push(post);
+      } else {
+        map.set(slug, { tag, posts: [post] });
+      }
+    }
+  }
+  return [...map.entries()].map(([slug, value]) => ({
+    params: { tag: slug },
+    props: { tag: value.tag, posts: value.posts }
+  }));
+}
+
+const { tag, posts } = Astro.props;
+const slug = Astro.params.tag;
+
+const title = `#${tag} — Writing by Ralph Jonas Mungcal`;
+const description = `Posts tagged ${tag}: ${posts.length} ${posts.length === 1 ? 'post' : 'posts'} on ${tag} by Ralph Jonas Mungcal.`;
+const canonicalURL = `https://ralphjonas.com/blog/tags/${slug}/`;
+const dateModified = posts
+  .map((p) => (p.data.updatedDate ?? p.data.pubDate).valueOf())
+  .reduce((a, b) => Math.max(a, b), 0);
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
+    { '@type': 'ListItem', position: 2, name: 'Writing', item: 'https://ralphjonas.com/blog/' },
+    { '@type': 'ListItem', position: 3, name: `#${tag}`, item: canonicalURL }
+  ]
+};
+
+const collectionPage = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  '@id': `${canonicalURL}#collectionpage`,
+  url: canonicalURL,
+  name: title,
+  description,
+  inLanguage: 'en',
+  isPartOf: { '@id': 'https://ralphjonas.com/#website' },
+  about: { name: tag },
+  hasPart: posts.map((post) => ({
+    '@type': 'BlogPosting',
+    '@id': `https://ralphjonas.com/blog/${post.id}/#blogposting`,
+    headline: post.data.title,
+    url: `https://ralphjonas.com/blog/${post.id}/`,
+    datePublished: post.data.pubDate.toISOString()
+  }))
+};
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  canonicalURL={canonicalURL}
+  breadcrumb={breadcrumb}
+  dateModified={new Date(dateModified).toISOString()}
+>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(collectionPage)}></script>
+  </Fragment>
+
+  <main class="blog-page">
+    <h1 class="visually-hidden">Posts tagged {tag}</h1>
+
+    <div class="blog-shell-bar" role="banner">
+      <div class="blog-shell-bar-dots" aria-hidden="true">
+        <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
+        <span class="blog-shell-bar-dot"></span>
+        <span class="blog-shell-bar-dot"></span>
+      </div>
+      <span>ralph@jonas:~/writing — grep #{tag}</span>
+    </div>
+
+    <div class="blog-header">
+      <span class="blog-header-prompt">$</span>
+      <span class="blog-header-cmd">grep -l "#{tag}" ./writing/</span>
+    </div>
+    <hr class="blog-rule" role="presentation" />
+
+    <p class="blog-intro">
+      {posts.length} {posts.length === 1 ? 'post' : 'posts'} tagged <strong>#{tag}</strong>.
+      <a href="/blog/tags/" style="color: var(--color-accent); margin-left: 0.5rem;">all tags &rarr;</a>
+    </p>
+
+    <ul class="blog-list" role="list">
+      {posts.map((post) => (
+        <li class="blog-list-item">
+          <article>
+            <a href={`/blog/${post.id}/`} class="blog-list-link">
+              <time class="blog-list-date" datetime={post.data.pubDate.toISOString()}>
+                {formatPubDate(post.data.pubDate)}
+              </time>
+              <span class="blog-list-title">{post.data.title}</span>
+              <span class="blog-list-arrow" aria-hidden="true">&rarr;</span>
+            </a>
+          </article>
+        </li>
+      ))}
+    </ul>
+
+    <div class="post-nav">
+      <a href="/blog/" class="post-nav-link">&larr; all posts</a>
+      <a href="/blog/tags/" class="post-nav-link">all tags</a>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,0 +1,90 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { getAllTags } from '../../../utils/blog';
+import '../../../styles/blog.css';
+
+const tags = await getAllTags();
+
+const title = 'Tags — Writing by Ralph Jonas Mungcal';
+const description = 'Browse posts by topic — software engineering, AI integration, career, and craft.';
+const canonicalURL = 'https://ralphjonas.com/blog/tags/';
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
+    { '@type': 'ListItem', position: 2, name: 'Writing', item: 'https://ralphjonas.com/blog/' },
+    { '@type': 'ListItem', position: 3, name: 'Tags', item: canonicalURL }
+  ]
+};
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  canonicalURL={canonicalURL}
+  breadcrumb={breadcrumb}
+>
+  <main class="blog-page">
+    <h1 class="visually-hidden">All tags</h1>
+
+    <div class="blog-shell-bar" role="banner">
+      <div class="blog-shell-bar-dots" aria-hidden="true">
+        <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
+        <span class="blog-shell-bar-dot"></span>
+        <span class="blog-shell-bar-dot"></span>
+      </div>
+      <span>ralph@jonas:~/writing — ls tags/</span>
+    </div>
+
+    <div class="blog-header">
+      <span class="blog-header-prompt">$</span>
+      <span class="blog-header-cmd">ls ./tags/</span>
+      <span class="blog-header-flag">--by-count</span>
+    </div>
+    <hr class="blog-rule" role="presentation" />
+
+    <p class="blog-intro">browse posts by topic. {tags.length} tags total.</p>
+
+    <ul class="tag-cloud" role="list">
+      {tags.map((entry) => (
+        <li>
+          <a class="post-tag" href={`/blog/tags/${entry.slug}/`}>
+            #{entry.tag} <span style="color: var(--color-ink-muted); margin-left: 0.25rem;">{entry.count}</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+
+    <div class="post-nav">
+      <a href="/blog/" class="post-nav-link">&larr; all posts</a>
+      <a href="/" class="post-nav-link">$ cd ~/</a>
+    </div>
+  </main>
+
+  <style>
+    .tag-cloud {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 2.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+    }
+
+    .tag-cloud .post-tag {
+      font-size: 0.95rem;
+      padding: 0.4rem 0.7rem;
+      text-decoration: none;
+      transition: transform 0.12s ease, background 0.12s ease;
+    }
+
+    .tag-cloud .post-tag:hover,
+    .tag-cloud .post-tag:focus-visible {
+      background: var(--color-accent);
+      transform: translate(-2px, -2px);
+      outline: none;
+    }
+  </style>
+</BaseLayout>

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -222,6 +222,15 @@
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--color-ink);
+  text-decoration: none;
+  transition: background 0.12s ease, transform 0.12s ease;
+}
+
+a.post-tag:hover,
+a.post-tag:focus-visible {
+  background: var(--color-accent);
+  transform: translate(-1px, -1px);
+  outline: none;
 }
 
 .post-rule {

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -46,6 +46,33 @@ export function getReadingTimeMinutes(wordCount: number): number {
   return Math.max(1, Math.round(wordCount / 225));
 }
 
+export function tagToSlug(tag: string): string {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export async function getAllTags(): Promise<{ tag: string; slug: string; count: number }[]> {
+  const posts = await getPublishedPosts();
+  const counts = new Map<string, { tag: string; count: number }>();
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const slug = tagToSlug(tag);
+      const current = counts.get(slug);
+      if (current) {
+        current.count += 1;
+      } else {
+        counts.set(slug, { tag, count: 1 });
+      }
+    }
+  }
+  return [...counts.entries()]
+    .map(([slug, value]) => ({ slug, tag: value.tag, count: value.count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
 export function getRelatedPosts(
   current: BlogEntry,
   all: BlogEntry[],


### PR DESCRIPTION
## Summary
- Define the `WebSite` schema node referenced via `isPartOf` but previously undefined, and wrap page JSON-LD in `@graph` with shared Person + WebSite nodes
- Generate per-post 1200x630 OG images from frontmatter via a new `prebuild` script (sharp + SVG); `BlogPosting.image` / `og:image` now use `/og/<slug>.png`
- Add `/blog/tags/<slug>/` archive routes + `/blog/tags/` index with `CollectionPage` JSON-LD; post tags link into the archives
- Stop emitting build-time `dateModified` on `WebPage` (caused lastmod churn); pages now pass explicit dates derived from frontmatter
- Mark 404 `noindex,follow` via a new `BaseLayout` prop; pin `Person.description` so it no longer leaks the current page's description

## Test plan
- [x] `npm run build` succeeds — 32 pages including 17 tag archives
- [x] `dist/blog/<slug>/index.html` references `/og/<slug>.png` in `og:image` and `BlogPosting.image`
- [x] `dist/blog/<slug>/index.html` `dateModified` matches `pubDate`/`updatedDate`, not build time
- [x] `dist/index.html` JSON-LD contains `@type: WebSite` and `@type: Person` graph nodes
- [x] `dist/404.html` has `<meta name="robots" content="noindex, follow">`
- [x] `dist/sitemap-0.xml` includes all 17 tag archive URLs
- [ ] Validate JSON-LD in Google's Rich Results Test after deploy
- [ ] Confirm new OG images render correctly when shared on X / LinkedIn