### PR TITLE
refactor(home): rework projects list

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,10 +19,10 @@ const HERO_SUBTITLE = 'full-stack developer & ai integration specialist. i build
 const featuredProjects = [
   { name: 'flight-rewards-search', stack: ['Node.js', 'TypeScript', 'PostgreSQL', 'GCP'], description: 'Technical lead for a UK-based SaaS — reward flight availability search across major airlines.' },
   { name: 'billing-payment-platform', stack: ['Node.js', 'TypeScript', 'GCP', 'Event-driven'], description: 'Multi-gateway payment orchestration with unified subscription billing, dunning, and smart retry.' },
-  { name: 'airline-data-bots', stack: ['TypeScript', 'Puppeteer', 'BullMQ'], description: 'Automated scrapers collecting flight availability data from multiple airline sources on schedule.' },
-  { name: 'remote-mcp-server', stack: ['TypeScript', 'Node.js', 'Docker'], description: 'Model Context Protocol server over URL — AI assistants hit custom tools via SSE transport.' },
-  { name: 'home-infra-lab', stack: ['Docker', 'Linux', 'TrueNAS', 'Tailscale'], description: 'Multi-node self-hosted services — NAS, media, workflow automation, monitoring dashboards.' },
-  { name: 'ai-meeting-editor', stack: ['Python', 'Whisper', 'Deepgram', 'FFmpeg', 'PyTorch', 'AWS'], description: 'AI-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.' }
+  { name: 'subscription-event-bus', stack: ['Node.js', 'GCP', 'Pub/Sub'], description: 'Event-driven subscription billing on GCP Pub/Sub — async lifecycle fan-out, idempotent consumers, retry and dead-letter handling.' },
+  { name: 'ai-meeting-editor', stack: ['Python', 'Whisper', 'Deepgram', 'FFmpeg', 'PyTorch', 'AWS'], description: 'AI-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.' },
+  { name: 'ai-dev-workflow-standards', stack: ['Claude', 'OpenAI'], description: 'Internal standards for AI-assisted dev — agent setup, prompt patterns, review gates for the team.' },
+  { name: 'airline-data-bots', stack: ['TypeScript', 'Puppeteer', 'BullMQ'], description: 'Automated scrapers collecting flight availability data from multiple airline sources on schedule.' }
 ];
 
 const sideProjects = [
@@ -215,24 +215,24 @@ const sideProjectItemList = {
             <p class="project-desc">multi-gateway payment orchestration with unified subscription billing, dunning, smart retry.</p>
           </li>
           <li class="project-row motion-stagger">
-            <span class="project-name">airline-data-bots</span>
-            <span class="project-tech">ts · puppeteer · bullmq</span>
-            <p class="project-desc">automated scrapers collecting flight availability data from multiple airline sources on schedule.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">remote-mcp-server</span>
-            <span class="project-tech">ts · node · docker</span>
-            <p class="project-desc">model context protocol server over url — ai assistants hit custom tools via sse transport.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">home-infra-lab</span>
-            <span class="project-tech">docker · linux · truenas · tailscale</span>
-            <p class="project-desc">multi-node self-hosted services — nas, media, workflow automation, monitoring dashboards.</p>
+            <span class="project-name">subscription-event-bus</span>
+            <span class="project-tech">node · gcp · pub/sub</span>
+            <p class="project-desc">event-driven subscription billing on gcp pub/sub — async lifecycle fan-out, idempotent consumers, retry and dead-letter handling.</p>
           </li>
           <li class="project-row motion-stagger">
             <span class="project-name">ai-meeting-editor</span>
             <span class="project-tech">python · whisper · deepgram · ffmpeg · pytorch · aws</span>
             <p class="project-desc">ai-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.</p>
+          </li>
+          <li class="project-row motion-stagger">
+            <span class="project-name">ai-dev-workflow-standards</span>
+            <span class="project-tech">claude · openai</span>
+            <p class="project-desc">internal standards for ai-assisted dev — agent setup, prompt patterns, review gates for the team.</p>
+          </li>
+          <li class="project-row motion-stagger">
+            <span class="project-name">airline-data-bots</span>
+            <span class="project-tech">ts · puppeteer · bullmq</span>
+            <p class="project-desc">automated scrapers collecting flight availability data from multiple airline sources on schedule.</p>
           </li>
         </ul>
 
@@ -240,40 +240,36 @@ const sideProjectItemList = {
 
         <ul class="project-list" role="list" style="grid-template-columns: 1fr;">
           <li class="compact-row motion-stagger">
-            <span class="compact-name">airline-route-mapping</span>
-            <span class="compact-tech">ts · node</span>
+            <span class="compact-name">remote-mcp-server</span>
+            <span class="compact-tech">ts · node · docker</span>
+            <p class="compact-desc">model context protocol server over url — ai assistants hit custom tools via sse transport.</p>
+          </li>
+          <li class="compact-row motion-stagger">
+            <span class="compact-name">home-infra-lab</span>
+            <span class="compact-tech">docker · linux · truenas · tailscale</span>
+            <p class="compact-desc">multi-node self-hosted services — nas, media, workflow automation, monitoring dashboards.</p>
           </li>
           <li class="compact-row motion-stagger">
             <span class="compact-name">loyalty-points-transfer</span>
             <span class="compact-tech">node · ts · react</span>
-          </li>
-          <li class="compact-row motion-stagger">
-            <span class="compact-name">subscription-architecture</span>
-            <span class="compact-tech">node · gcp · pub/sub</span>
-          </li>
-          <li class="compact-row motion-stagger">
-            <span class="compact-name">ai-dev-workflow-standards</span>
-            <span class="compact-tech">claude · openai</span>
+            <p class="compact-desc">cross-program loyalty point transfer flow — backend conversion logic with a clean ui on top.</p>
           </li>
           <li class="compact-row motion-stagger">
             <span class="compact-name">local-ai-inference-server</span>
             <span class="compact-tech">linux · ml-inference</span>
+            <p class="compact-desc">self-hosted inference box for local llm + transcription workloads — keep data off the cloud.</p>
           </li>
           <li class="compact-row motion-stagger">
-            <span class="compact-name">accident-detection-device</span>
-            <span class="compact-tech">rpi · python</span>
-          </li>
-          <li class="compact-row motion-stagger">
-            <span class="compact-name">accident-detection-panel</span>
-            <span class="compact-tech">mongo · express · angular · node</span>
+            <span class="compact-name">airline-route-mapping</span>
+            <span class="compact-tech">ts · node</span>
           </li>
           <li class="compact-row motion-stagger">
             <span class="compact-name">audit-report-generator</span>
             <span class="compact-tech">angular · node · sql · aws</span>
           </li>
           <li class="compact-row motion-stagger">
-            <span class="compact-name">freelance-projects</span>
-            <span class="compact-tech">upwork</span>
+            <span class="compact-name">accident-detection-system</span>
+            <span class="compact-tech">rpi · python · mongo · express · angular</span>
           </li>
         </ul>
       </div>

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -14,7 +14,7 @@ const nowProjects: Array<{
   { name: 'ascii-art-gen',  url: 'https://ascii-art-gen.fly.dev/',  status: 'iterating', update: 'Polishing UX + adding image upload.' },
   { name: 'subconscious',   url: 'https://subconsciousapp.co',      status: 'iterating', update: 'Iterating on notifications and export.' },
   { name: 'spot-the-synth', url: 'https://spotthesynth.com',        status: 'iterating', update: 'Community moderation tooling next.' },
-  { name: 'the-leon-files', url: 'https://theleonfiles.com',        status: 'iterating', update: 'Content + UI touch-ups.' }
+  { name: 'the-leon-files', url: 'https://theleonfiles.com',        status: 'iterating', update: 'Resident Evil fan site (Leon Kennedy) — content + UI touch-ups.' }
 ];
 
 const NOW_UPDATED = '2026-04-22';

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -555,6 +555,14 @@ a.brut-card {
   color: var(--color-ink-muted);
 }
 
+.compact-desc {
+  width: 100%;
+  margin: 0.25rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--color-ink-soft);
+}
+
 /* ===== Side Projects ===== */
 .side-project-intro {
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- Promote subscription-event-bus and ai-dev-workflow-standards to featured
- Push mcp/home-infra into other-work with short descriptions
- Merge the two accident-detection rows
- Add `.compact-desc` styles for new other-work blurbs
- Clarify the-leon-files on /now

## Test plan
- [ ] Verify featured grid renders subscription-event-bus and ai-dev-workflow-standards
- [ ] Verify other-work section shows mcp/home-infra with compact descriptions
- [ ] Verify accident-detection appears once
- [ ] Verify /now page shows updated the-leon-files copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)