### PR TITLE
feat(projects): Add project content collection and detail pages

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,4 +14,28 @@ const blog = defineCollection({
   })
 });
 
-export const collections = { blog };
+const projects = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/projects' }),
+  schema: z.object({
+    name: z.string(),
+    title: z.string(),
+    description: z.string(),
+    summary: z.string(),
+    stack: z.array(z.string()).default([]),
+    tech: z.string().optional(),
+    role: z.string().optional(),
+    year: z.string().optional(),
+    status: z.enum(['active', 'shipped', 'archived', 'ongoing']).default('shipped'),
+    featured: z.boolean().default(false),
+    order: z.number().default(0),
+    links: z
+      .array(z.object({ label: z.string(), url: z.string().url() }))
+      .default([]),
+    keywords: z.array(z.string()).default([]),
+    updatedDate: z.coerce.date().optional(),
+    draft: z.boolean().default(false),
+    canonical: z.string().url().optional()
+  })
+});
+
+export const collections = { blog, projects };

--- a/src/content/projects/ai-dev-workflow-standards.md
+++ b/src/content/projects/ai-dev-workflow-standards.md
@@ -1,0 +1,57 @@
+---
+name: ai-dev-workflow-standards
+title: AI-Assisted Developer Workflow Standards
+description: Internal standards for AI-assisted development — agent setup, prompt patterns, repo conventions, and review gates that make Claude- and OpenAI-driven coding consistent and reviewable across a team.
+summary: An opinionated playbook for using AI coding agents on a real codebase — how agents are configured, what they're allowed to do unattended, what they're not, and how their output gets reviewed before it lands. Built around Claude and OpenAI tooling.
+stack:
+  - Claude (Anthropic)
+  - Claude Code
+  - OpenAI
+  - GitHub
+  - Conventional Commits
+tech: claude · openai
+role: Author — standards, agent configuration, review process
+status: ongoing
+featured: true
+order: 5
+keywords:
+  - ai assisted development
+  - claude code workflow
+  - prompt engineering team
+  - ai code review
+  - agent guardrails
+  - ai dev standards
+---
+
+## What it does
+
+A team-level standard for how AI coding agents are used day to day. It covers the boring-but-load-bearing parts: how repos are set up to be agent-friendly, which prompts and skills are reusable, what's allowed without human review, and how AI-generated PRs are evaluated against the same bar as human ones — not a higher one, not a lower one.
+
+## What's in scope
+
+- **Agent configuration** — `CLAUDE.md` and equivalent root-level instructions per repo, including parallel-execution rules, sensitive-file protection, branch hygiene, and commit message conventions.
+- **Prompt patterns** — reusable prompts for common tasks (triage, refactor planning, code review, test generation), with explicit success criteria so the agent knows when it's done.
+- **Skill libraries** — composable skills for things like Conventional Commits, PR review, debugging, and TDD, plus rules for when each one fires.
+- **Review gates** — what an AI-generated change must satisfy before merge: passing CI, no secrets touched, no unrelated drive-by changes, commit messages that read like a human wrote them.
+- **Sensitive surfaces** — explicit deny lists (`.env`, credentials directories, customer data) wired into both the agent config and the harness so they're enforced, not aspirational.
+
+## Why it exists
+
+Without standards, every AI-assisted PR is a coin flip — sometimes excellent, sometimes a sprawling mess that touches twelve files for a one-line fix. The goal is to make AI output predictable enough that reviewers can trust the process, not just inspect every diff line by line. The standards aim at:
+
+- **Atomic, reviewable commits** instead of "AI did a thing" mega-PRs.
+- **Plain commit messages** with no AI tells, em dashes, or marketing prose.
+- **Stable repo conventions** so the same prompt produces broadly the same shape of change next month.
+- **Safety by default** — destructive actions, force pushes, and secret access require explicit human approval, not a polite ask.
+
+## Tech rationale
+
+- **Claude Code as the primary agent harness** — strong tool ergonomics, scriptable skills, and a hook system that lets us enforce policy at the harness layer instead of trusting the model to remember.
+- **OpenAI for adjacent tooling** — embeddings, evaluation, and lighter inline assists where it's a better fit.
+- **GitHub as the integration point** — PRs, reviews, and CI are where the standards bite. Anything below the PR layer is process; the PR is where evidence shows up.
+
+## What I focus on
+
+- Writing the CLAUDE.md / agent rule layer so the right behaviors are the path of least resistance.
+- Designing review gates that catch AI-specific failure modes (over-eager refactors, fabricated APIs, sycophantic agreement) without blocking the wins.
+- Keeping the standards short enough to actually be read.

--- a/src/content/projects/ai-meeting-editor.md
+++ b/src/content/projects/ai-meeting-editor.md
@@ -1,0 +1,55 @@
+---
+name: ai-meeting-editor
+title: AI Meeting Editor — Auto-Trim Dead Air
+description: AI-powered meeting editor that detects the real start and end of a discussion and trims dead air using Whisper, Deepgram, FFmpeg, and PyTorch on AWS — transcripts plus voice-activity heuristics, not just silence detection.
+summary: A media pipeline that takes raw meeting recordings and returns clean cuts with the small talk, setup chatter, and dead air removed. Combines ASR (Whisper / Deepgram), voice-activity detection, and lightweight semantic boundary models to find where the conversation actually starts and ends.
+stack:
+  - Python
+  - OpenAI Whisper
+  - Deepgram
+  - FFmpeg
+  - PyTorch
+  - AWS
+  - S3
+  - Lambda
+tech: python · whisper · deepgram · ffmpeg · pytorch · aws
+role: Builder — pipeline design, ASR integration, audio processing
+status: active
+featured: true
+order: 4
+keywords:
+  - ai meeting editor
+  - whisper transcription
+  - deepgram speech to text
+  - voice activity detection
+  - ffmpeg audio trimming
+  - pytorch audio
+  - aws media pipeline
+---
+
+## What it does
+
+Drop in a meeting recording — long, messy, with five minutes of "can you hear me?" at the start and a tail of post-meeting chitchat — and get back a trimmed version that begins where the actual conversation begins and ends where it actually ends. No manual scrubbing. No naive silence-only trim that decapitates a sentence because someone paused for breath.
+
+## Pipeline
+
+The processing pipeline is staged so each step does one thing well and intermediate artifacts are cacheable.
+
+1. **Ingest** — raw audio/video uploads land in S3. A trigger normalizes audio (mono, 16kHz PCM) with FFmpeg.
+2. **Transcribe** — Whisper for offline batches where cost matters, Deepgram for low-latency paths. Both produce word-level timestamps.
+3. **Voice activity detection** — a PyTorch VAD pass marks speech vs. silence at frame resolution, separate from the transcript. This is what distinguishes dead air from a meaningful pause.
+4. **Boundary detection** — combine VAD spans with transcript content to find the first and last "substance" moments. A short content classifier filters out greetings, mic checks, and outros so the cut lands on the real start, not the first audible word.
+5. **Cut** — FFmpeg trims with stream copy where possible (no re-encode = fast + lossless), re-encoding only when necessary.
+
+## Tech rationale
+
+- **Whisper + Deepgram, not one or the other** — Whisper is great offline and locally controllable; Deepgram wins on streaming and turnaround. The system picks per job based on latency and cost budget.
+- **PyTorch VAD over FFmpeg silence detection** — silence detection alone confuses thoughtful pauses with dead air. A learned VAD is dramatically more accurate at the speech/non-speech boundary.
+- **FFmpeg as the muscle** — trimming, normalization, and remuxing are FFmpeg's home turf. Doing it natively keeps the pipeline fast and cheap.
+- **AWS for the runtime** — S3 for blob storage, Lambda for short steps, larger compute for the GPU-backed steps. Cost-controlled and easy to scale per stage independently.
+
+## What I focus on
+
+- Designing the boundary-detection logic so it gets the obvious cases right and degrades gracefully on the weird ones (long silences mid-meeting, multiple speakers talking over the start).
+- Cost shape: choosing the right ASR per job, caching transcripts, and making sure we never re-transcribe the same file twice.
+- Operability: observable per-stage timings, retryable steps, and idempotent outputs so a partial failure isn't a full re-run.

--- a/src/content/projects/airline-data-bots.md
+++ b/src/content/projects/airline-data-bots.md
@@ -1,0 +1,58 @@
+---
+name: airline-data-bots
+title: Airline Data Bots — Scheduled Availability Scrapers
+description: Automated scrapers that collect flight availability data from multiple airline sources on schedule — TypeScript and Puppeteer for the headless browser layer, BullMQ for distributed job scheduling and retries.
+summary: A fleet of scheduled scrapers that pull flight availability from multiple airline sources, normalize the results, and publish them into the search platform. Built around a Puppeteer pool, a BullMQ-backed queue, and retry/backoff policies that survive the messy realities of public airline endpoints.
+stack:
+  - TypeScript
+  - Node.js
+  - Puppeteer
+  - BullMQ
+  - Redis
+  - Docker
+tech: ts · puppeteer · bullmq
+role: Builder — scraper architecture, queueing, reliability
+status: active
+featured: true
+order: 6
+keywords:
+  - puppeteer scraping
+  - bullmq queue
+  - airline data scraping
+  - scheduled scrapers
+  - typescript node scraping
+  - headless browser pool
+---
+
+## What it does
+
+A scheduled, distributed scraping system that keeps the search platform's data fresh. Each scraper targets one upstream source, runs on its own cadence, and produces normalized availability records. The platform doesn't care which source data came from once it's normalized — but the work to get it there is where most of the engineering goes.
+
+## Architecture
+
+- **Job queue on BullMQ + Redis** — every scrape is a queued job, with priority, rate-limiting per source, and retry policies. Throughput is controlled per queue, not per worker, so adding capacity doesn't accidentally hammer an upstream.
+- **Worker pool** — a fleet of Node.js workers in containers, each capable of running any scraper. Workers pull jobs and run the appropriate Puppeteer flow.
+- **Headless browser pool** — Puppeteer instances are pooled and recycled rather than launched per job. Cold-start of a browser is the most expensive thing in the system, so we amortize it.
+- **Normalization layer** — each scraper's raw output is funneled through a per-source adapter that maps to the shared availability schema before publishing.
+
+## Reliability patterns
+
+Scraping public airline pages is a war of attrition: layouts change, anti-bot defenses tighten, sessions expire mid-flow. The system is built around the assumption that any individual run can fail.
+
+- **Retry with budget** — exponential backoff on transient failures, hard cap on attempts so a broken scraper fails loud instead of burning quota.
+- **Per-source rate limiting** — Redis-backed token bucket per source so we stay polite even when many workers pull jobs concurrently.
+- **Health probes per scraper** — small, cheap synthetic runs detect "this scraper is broken" before a daily run reveals a 24-hour data gap.
+- **Snapshotting on failure** — page HTML and DOM dumps captured for any failed run, so debugging "why did this break overnight" doesn't require reproducing the failure live.
+
+## Tech rationale
+
+- **Puppeteer over raw HTTP** — these sources rely heavily on client-side rendering and runtime checks. A headless browser is the right level of abstraction; trying to reimplement it as HTTP calls is a tar pit.
+- **BullMQ over a hand-rolled scheduler** — it gives us repeatable jobs, retries, rate limiting, and observability out of the box, all backed by Redis.
+- **TypeScript** — scraper outputs share a strict schema with the search platform, so a parser drift becomes a type error instead of a silent data corruption.
+- **Docker** for repeatable worker environments, including pinned browser versions (the surface area where "works on my machine" actually bites).
+
+## What I focus on
+
+- Designing the queue topology and rate-limiting so we get fresh data without ever overwhelming upstreams.
+- Keeping scrapers small and per-source — one parser change should never blast-radius into the others.
+- Observability: per-source freshness, success rate, parser drift detection, and snapshot capture for forensics.

--- a/src/content/projects/billing-payment-platform.md
+++ b/src/content/projects/billing-payment-platform.md
@@ -1,0 +1,60 @@
+---
+name: billing-payment-platform
+title: Multi-Gateway Billing & Payment Platform
+description: Payment orchestration across multiple gateways with unified subscription billing, dunning, and smart retry logic — built in TypeScript on an event-driven GCP stack.
+summary: A unified subscription billing layer that abstracts multiple payment gateways behind a single domain model. Handles charges, refunds, retries, dunning, and lifecycle events without leaking gateway-specific quirks into product code.
+stack:
+  - Node.js
+  - TypeScript
+  - Google Cloud Platform
+  - Pub/Sub
+  - Cloud Run
+  - PostgreSQL
+  - Event-driven architecture
+tech: node · ts · gcp · event-driven
+role: Backend engineer — payment orchestration, subscription lifecycle, reliability
+status: active
+featured: true
+order: 2
+keywords:
+  - subscription billing platform
+  - payment gateway orchestration
+  - dunning automation
+  - smart retry payments
+  - event-driven billing
+  - typescript node payments
+---
+
+## What it does
+
+A subscription billing and payment orchestration platform sitting in front of multiple payment gateways. Product teams call one API ("charge this customer for this plan") and the platform handles gateway selection, idempotency, retries, refunds, dunning, and the long tail of subscription lifecycle events — without any of the gateway-specific quirks bleeding upward.
+
+## Architecture
+
+The system is event-driven by design. Every meaningful state change — `charge.attempted`, `charge.failed`, `subscription.renewed`, `invoice.paid`, `dunning.escalated` — is a published event, and downstream consumers (notifications, accounting export, customer ops dashboards) subscribe instead of polling.
+
+- **Gateway adapter layer** — each gateway (Stripe-style and others) sits behind a common interface that maps gateway responses to a normalized domain model (decline reasons, network codes, retry hints).
+- **Subscription engine** — owns plan/period state, proration, trial handling, mid-cycle changes, and renewal scheduling.
+- **Dunning state machine** — explicit states (`grace`, `soft_decline`, `hard_decline`, `recovered`, `churned`) with clear transitions, retry windows, and customer communication hooks.
+- **Event bus on Pub/Sub** — durable fan-out across services with at-least-once delivery; consumers are idempotent by design.
+
+## Reliability primitives
+
+A payment platform is mostly a reliability project. The core building blocks:
+
+- **Idempotency keys** at every external write. The same logical charge attempt can be retried safely, end-to-end.
+- **Outbox pattern** for state-change events so we never have a "charged but didn't notify" or "notified but didn't charge" window.
+- **Smart retry** — decline-code-aware backoff that distinguishes retriable failures (network, gateway timeout, soft decline) from terminal ones (lost card, fraud block) so we don't burn customer trust by retrying things that will never succeed.
+- **Replay-safe consumers** — every event handler is written so reprocessing a backlog is a yawn, not an incident.
+
+## Tech rationale
+
+- **TypeScript end-to-end** for compile-time guarantees on money, currency, and state transitions — the places where a stringly-typed bug hurts the most.
+- **GCP Pub/Sub** for the bus because it gives durable, scalable fan-out without us having to operate a message broker.
+- **Cloud Run** for the stateless services and **PostgreSQL** for the system of record (subscriptions, invoices, ledger entries).
+
+## What I focus on
+
+- Designing the dunning state machine and retry policies so recovery rates improve without spamming customers.
+- Building the gateway adapter abstractions so adding a new gateway is a finite, well-scoped piece of work — not a refactor.
+- Hardening the event pipeline: idempotency, ordering where it matters, dead-letter handling, and replay tooling.

--- a/src/content/projects/flight-rewards-search.md
+++ b/src/content/projects/flight-rewards-search.md
@@ -1,0 +1,59 @@
+---
+name: flight-rewards-search
+title: Flight Rewards Search Engine
+description: Reward flight availability search across major airlines — Node.js + TypeScript backend, PostgreSQL search index, and GCP-hosted ingestion pipelines that keep award seat data fresh at scale.
+summary: Technical lead on a UK-based SaaS that searches reward flight availability across major airline programs. Backend, data ingestion, and search infrastructure built on Node.js, TypeScript, PostgreSQL, and Google Cloud Platform.
+stack:
+  - Node.js
+  - TypeScript
+  - PostgreSQL
+  - Google Cloud Platform
+  - Cloud Run
+  - Pub/Sub
+  - Redis
+tech: node · ts · postgres · gcp
+role: Technical Lead — backend, data pipelines, search architecture
+status: active
+featured: true
+order: 1
+keywords:
+  - reward flight search
+  - award availability
+  - airline data engineering
+  - postgres search
+  - node typescript backend
+  - gcp cloud run
+---
+
+## What it does
+
+A reward flight search engine that aggregates award seat availability across multiple airline loyalty programs and lets travellers query "where can I fly with X miles, on Y dates, in Z cabin?" in seconds. Award availability is famously volatile, fragmented across airline systems, and rate-limited at the source — so most of the engineering challenge sits in the ingestion and search layers, not the UI.
+
+## Architecture
+
+The platform splits into three loosely-coupled tiers, all running on Google Cloud Platform:
+
+- **Ingestion workers** — long-running Node.js services that pull availability from a rotating set of upstream sources, normalize cabin classes and routing rules, and publish change events.
+- **Search store** — PostgreSQL as the canonical store, with carefully-tuned indexes for `(origin, destination, date, cabin, program)` lookups. Hot routes are cached in Redis with short TTLs to absorb traffic spikes without re-querying the source of truth.
+- **Query API** — stateless TypeScript service on Cloud Run that exposes the consumer-facing search endpoints, handles auth, and applies result-side filtering (mileage tiers, mixed-cabin, layover constraints).
+
+Pub/Sub sits between ingestion and search as the change feed, which keeps each tier independently scalable and lets us replay events when we change the schema or fix a parsing bug.
+
+## Tech rationale
+
+- **TypeScript everywhere** — the same domain types (program, cabin, segment, fare class) flow from the scrapers through the API into the SDK, so a schema change is a compile-time problem instead of a 3am production problem.
+- **PostgreSQL over a search engine** — for this dataset (millions of segments, structured query shape) a well-indexed Postgres table with partial indexes on hot columns and BRIN indexes on time-bucketed partitions outperforms a general-purpose search engine and is dramatically cheaper to operate.
+- **Cloud Run for the API** — request-scoped autoscaling and scale-to-zero match the bursty, search-driven traffic pattern. Long-running ingestion workers run on dedicated GCE/Cloud Run jobs so they don't fight the API for cold-start budget.
+
+## What I focus on
+
+- Designing the ingestion → store → query data flow end-to-end.
+- Index strategy and query plans for the search hotpath (the difference between 50ms and 5s lives here).
+- Backpressure and rate limiting against upstream sources so we stay polite and don't get cut off.
+- Observability: structured logs, per-source freshness SLOs, and alerting on data drift.
+
+## Highlights
+
+- Sub-second response on the most-queried route/date combinations.
+- Schema-versioned change feed so a parser fix can be replayed across historical events without a full re-scrape.
+- Cost profile that keeps GCP spend predictable as catalogue size grows, by separating "always warm" hot data from cold archives.

--- a/src/content/projects/subscription-event-bus.md
+++ b/src/content/projects/subscription-event-bus.md
@@ -1,0 +1,55 @@
+---
+name: subscription-event-bus
+title: Subscription Event Bus on GCP Pub/Sub
+description: Event-driven subscription billing on Google Cloud Pub/Sub — async lifecycle fan-out, idempotent consumers, retry policies, and dead-letter handling that keep billing reliable under load.
+summary: The event backbone behind subscription billing — a Pub/Sub-based bus that fans subscription lifecycle changes out to billing, notifications, analytics, and ops consumers. Designed for at-least-once delivery, idempotent processing, and clean recovery from upstream failures.
+stack:
+  - Node.js
+  - TypeScript
+  - Google Cloud Pub/Sub
+  - Cloud Run
+  - PostgreSQL
+  - Event-driven architecture
+tech: node · gcp · pub/sub
+role: Backend engineer — event architecture, consumer reliability
+status: active
+featured: true
+order: 3
+keywords:
+  - gcp pub sub
+  - event-driven subscription billing
+  - idempotent consumers
+  - dead letter queue
+  - fan-out architecture
+  - subscription lifecycle events
+---
+
+## What it does
+
+The event bus that sits underneath the subscription billing platform. Lifecycle changes (`subscription.created`, `plan.changed`, `payment.failed`, `dunning.entered`, `subscription.canceled`) are published once and consumed by anything that cares: charging, notifications, internal dashboards, accounting export, retention experiments. Replacing in-process function calls with a durable event log decoupled the system enough that adding a new consumer no longer requires touching the producer.
+
+## Architecture
+
+- **Producers** — the subscription engine and payment workers publish domain events through a thin client that handles schema validation, ordering keys, and outbox-driven publish to guarantee "state changed ⇒ event published".
+- **Topics by domain, not by service** — `subscription.*`, `invoice.*`, `payment.*` topics with strongly-typed payloads, instead of one mega-topic. Consumers subscribe to what they need.
+- **Push subscriptions to Cloud Run** for stateless consumers; pull subscriptions for batch/analytical workloads.
+- **Dead-letter topics** on every subscription with alerting wired up — a poison message goes to DLQ, not into a hot retry loop.
+
+## Reliability patterns
+
+- **Idempotent consumers**. Every handler treats incoming events as "we may see this twice." Dedup on event ID + handler name in Postgres, with a TTL'd dedup table that's cheap to query.
+- **Ordering where it matters**. Subscription lifecycle uses ordering keys per subscription so a `canceled` can't be processed before its `created`. Where strict ordering isn't needed, we don't pay the throughput cost.
+- **Outbox pattern** between the writer and the bus — events are written transactionally with the state change, then a relay publishes them. No "charged but no event" failure mode.
+- **Backoff and DLQ tuning** — exponential retry with a ceiling, then DLQ. Replay tooling can drain the DLQ back into a subscription after a fix.
+
+## Tech rationale
+
+- **Pub/Sub over Kafka** — for this team and traffic profile, a fully managed broker with native GCP IAM and zero broker ops was the right call. We get durable, scalable fan-out without standing up a Kafka cluster.
+- **TypeScript schemas as the source of truth** — event contracts are TS types validated at publish time, so a malformed event is caught at the producer, not in a downstream consumer at 2am.
+- **Cloud Run consumers** — push subscriptions + scale-to-zero match bursty event volume well, and the same container can serve HTTP and consume events.
+
+## What I focus on
+
+- Event modeling — what's an event vs. what's a query — and naming/versioning so contracts can evolve.
+- Building consumer reliability primitives (idempotency, DLQ replay, backfill) once and reusing them.
+- Observability: event throughput, end-to-end latency from publish to processed, DLQ depth as a first-class SLO.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { getPublishedPosts, formatPubDate, toIsoDate } from '../utils/blog';
 import '../styles/home.css';
@@ -16,14 +17,19 @@ const blogPosts = allPosts.slice(0, MAX_POSTS).map((post) => ({
 
 const HERO_SUBTITLE = 'full-stack developer & ai integration specialist. i build scalable, practical software — backend architecture, cloud infra, dev tooling, ai-powered workflows.';
 
-const featuredProjects = [
-  { name: 'flight-rewards-search', stack: ['Node.js', 'TypeScript', 'PostgreSQL', 'GCP'], description: 'Technical lead for a UK-based SaaS — reward flight availability search across major airlines.' },
-  { name: 'billing-payment-platform', stack: ['Node.js', 'TypeScript', 'GCP', 'Event-driven'], description: 'Multi-gateway payment orchestration with unified subscription billing, dunning, and smart retry.' },
-  { name: 'subscription-event-bus', stack: ['Node.js', 'GCP', 'Pub/Sub'], description: 'Event-driven subscription billing on GCP Pub/Sub — async lifecycle fan-out, idempotent consumers, retry and dead-letter handling.' },
-  { name: 'ai-meeting-editor', stack: ['Python', 'Whisper', 'Deepgram', 'FFmpeg', 'PyTorch', 'AWS'], description: 'AI-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.' },
-  { name: 'ai-dev-workflow-standards', stack: ['Claude', 'OpenAI'], description: 'Internal standards for AI-assisted dev — agent setup, prompt patterns, review gates for the team.' },
-  { name: 'airline-data-bots', stack: ['TypeScript', 'Puppeteer', 'BullMQ'], description: 'Automated scrapers collecting flight availability data from multiple airline sources on schedule.' }
-];
+const projectEntries = await getCollection('projects', ({ data }) => !data.draft);
+const featuredProjects = projectEntries
+  .filter((entry) => entry.data.featured)
+  .sort((a, b) => a.data.order - b.data.order)
+  .slice(0, 6)
+  .map((entry) => ({
+    slug: entry.id,
+    name: entry.data.name,
+    stack: entry.data.stack,
+    tech: entry.data.tech ?? entry.data.stack.map((s) => s.toLowerCase()).join(' · '),
+    description: entry.data.description,
+    url: `/projects/${entry.id}/`
+  }));
 
 const sideProjects = [
   { name: 'subconscious', url: 'https://subconsciousapp.co', description: 'Subscription tracking — take control of recurring expenses.' },
@@ -39,9 +45,12 @@ const projectItemList = {
   itemListElement: featuredProjects.map((project, index) => ({
     '@type': 'ListItem',
     position: index + 1,
+    url: `https://ralphjonas.com${project.url}`,
     item: {
       '@type': 'CreativeWork',
+      '@id': `https://ralphjonas.com${project.url}#project`,
       name: project.name,
+      url: `https://ralphjonas.com${project.url}`,
       description: project.description,
       keywords: project.stack.join(', '),
       creator: { '@id': 'https://ralphjonas.com/#person' }
@@ -204,41 +213,21 @@ const sideProjectItemList = {
         <hr class="section-rule" role="presentation" />
 
         <ul class="project-list" role="list">
-          <li class="project-row motion-stagger">
-            <span class="project-name">flight-rewards-search</span>
-            <span class="project-tech">node · ts · postgres · gcp</span>
-            <p class="project-desc">technical lead for a uk-based saas — reward flight availability search across major airlines.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">billing-payment-platform</span>
-            <span class="project-tech">node · ts · gcp · event-driven</span>
-            <p class="project-desc">multi-gateway payment orchestration with unified subscription billing, dunning, smart retry.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">subscription-event-bus</span>
-            <span class="project-tech">node · gcp · pub/sub</span>
-            <p class="project-desc">event-driven subscription billing on gcp pub/sub — async lifecycle fan-out, idempotent consumers, retry and dead-letter handling.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">ai-meeting-editor</span>
-            <span class="project-tech">python · whisper · deepgram · ffmpeg · pytorch · aws</span>
-            <p class="project-desc">ai-powered meeting editor — auto-detects start and end of discussion, trims dead air to keep only the substance.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">ai-dev-workflow-standards</span>
-            <span class="project-tech">claude · openai</span>
-            <p class="project-desc">internal standards for ai-assisted dev — agent setup, prompt patterns, review gates for the team.</p>
-          </li>
-          <li class="project-row motion-stagger">
-            <span class="project-name">airline-data-bots</span>
-            <span class="project-tech">ts · puppeteer · bullmq</span>
-            <p class="project-desc">automated scrapers collecting flight availability data from multiple airline sources on schedule.</p>
-          </li>
+          {featuredProjects.map((project) => (
+            <li class="project-row motion-stagger">
+              <a class="project-link" href={project.url} aria-label={`Open project: ${project.name}`}>
+                <span class="project-name">{project.name}</span>
+                <span class="project-tech">{project.tech}</span>
+                <p class="project-desc">{project.description.toLowerCase()}</p>
+                <span class="project-link-arrow" aria-hidden="true">&rarr;</span>
+              </a>
+            </li>
+          ))}
         </ul>
 
         <h3 class="other-heading motion-fade">other-work</h3>
 
-        <ul class="project-list" role="list" style="grid-template-columns: 1fr;">
+        <ul class="project-list other-work-list" role="list">
           <li class="compact-row motion-stagger">
             <span class="compact-name">remote-mcp-server</span>
             <span class="compact-tech">ts · node · docker</span>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,0 +1,177 @@
+---
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import '../../styles/blog.css';
+import '../../styles/projects.css';
+
+export async function getStaticPaths() {
+  const projects = await getCollection('projects', ({ data }) => !data.draft);
+  return projects.map((project) => ({
+    params: { slug: project.id },
+    props: { project }
+  }));
+}
+
+const { project } = Astro.props;
+const { Content } = await render(project);
+
+const roleParts = project.data.role
+  ? project.data.role.split(/\s+[—–-]\s+/)
+  : [];
+const roleHeadline = roleParts[0]?.trim() ?? null;
+const roleResponsibilities = roleParts.slice(1).join(' — ');
+const roleItems = roleResponsibilities
+  ? roleResponsibilities.split(/\s*,\s*/).map((s) => s.trim()).filter(Boolean)
+  : [];
+
+const canonicalURL = project.data.canonical
+  ?? `https://ralphjonas.com/projects/${project.id}/`;
+
+const dateModified = project.data.updatedDate?.toISOString();
+const ogImage = 'https://ralphjonas.com/og.png';
+const ogImageAlt = `${project.data.title} — project by Ralph Jonas Mungcal`;
+
+const keywords = [
+  ...project.data.keywords,
+  ...project.data.stack
+].filter(Boolean);
+
+const creativeWork = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareSourceCode',
+  '@id': `${canonicalURL}#project`,
+  name: project.data.title,
+  alternateName: project.data.name,
+  description: project.data.description,
+  abstract: project.data.summary,
+  url: canonicalURL,
+  programmingLanguage: project.data.stack,
+  keywords: keywords.join(', '),
+  author: { '@id': 'https://ralphjonas.com/#person' },
+  creator: { '@id': 'https://ralphjonas.com/#person' },
+  isPartOf: { '@id': 'https://ralphjonas.com/#website' },
+  ...(dateModified ? { dateModified } : {}),
+  image: ogImage
+};
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
+    { '@type': 'ListItem', position: 2, name: 'Projects', item: 'https://ralphjonas.com/#projects' },
+    { '@type': 'ListItem', position: 3, name: project.data.title, item: canonicalURL }
+  ]
+};
+---
+
+<BaseLayout
+  title={`${project.data.title} — Ralph Jonas Mungcal`}
+  description={project.data.description}
+  canonicalURL={canonicalURL}
+  ogType="article"
+  ogImage={ogImage}
+  ogImageAlt={ogImageAlt}
+  dateModified={dateModified}
+  breadcrumb={breadcrumb}
+>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(creativeWork)}></script>
+  </Fragment>
+
+  <main
+    class="post-page project-page"
+    data-slug={project.id}
+    data-title={project.data.title}
+  >
+    <div class="blog-shell-bar" role="banner">
+      <div class="blog-shell-bar-dots" aria-hidden="true">
+        <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
+        <span class="blog-shell-bar-dot"></span>
+        <span class="blog-shell-bar-dot"></span>
+      </div>
+      <span>ralph@jonas:~/projects/{project.id} — readme.md</span>
+    </div>
+
+    <a href="/#projects" class="post-back" aria-label="Back to projects">
+      <span class="post-back-arrow" aria-hidden="true">&larr;</span>
+      <span class="post-back-label">all projects</span>
+    </a>
+
+    <article>
+      <div class="post-meta">
+        <span class="post-meta-prompt">$</span>
+        <span class="post-meta-cmd">cat {project.id}/readme.md</span>
+      </div>
+
+      <h1 class="post-title">
+        {project.data.name}<span class="post-period">_</span>
+      </h1>
+
+      <p class="project-tagline">{project.data.summary}</p>
+
+      <dl class="project-facts">
+        {roleHeadline && (
+          <div class="project-fact project-fact--role">
+            <dt>role</dt>
+            <dd>
+              <span class="project-role-headline">{roleHeadline}</span>
+              {roleItems.length > 0 && (
+                <ul class="project-role-list" role="list">
+                  {roleItems.map((item) => (
+                    <li class="project-role-item">{item}</li>
+                  ))}
+                </ul>
+              )}
+            </dd>
+          </div>
+        )}
+        {project.data.year && (
+          <div class="project-fact">
+            <dt>year</dt>
+            <dd>{project.data.year}</dd>
+          </div>
+        )}
+        {project.data.stack.length > 0 && (
+          <div class="project-fact project-fact--wide">
+            <dt>stack</dt>
+            <dd>
+              <ul class="project-stack" role="list">
+                {project.data.stack.map((tech) => (
+                  <li class="project-stack-chip">{tech}</li>
+                ))}
+              </ul>
+            </dd>
+          </div>
+        )}
+        {project.data.links.length > 0 && (
+          <div class="project-fact project-fact--wide">
+            <dt>links</dt>
+            <dd>
+              <ul class="project-links" role="list">
+                {project.data.links.map((link) => (
+                  <li>
+                    <a href={link.url} target="_blank" rel="noopener noreferrer">
+                      {link.label} &rarr;
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      <hr class="post-rule" role="presentation" />
+
+      <div class="post-content">
+        <Content />
+      </div>
+    </article>
+
+    <nav class="post-nav" aria-label="Project navigation">
+      <a href="/#projects" class="post-nav-link">&larr; all projects</a>
+      <a href="/" class="post-nav-link">$ cd ~/</a>
+    </nav>
+  </main>
+</BaseLayout>

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -391,7 +391,7 @@ a.brut-card {
   border: var(--border-w) solid var(--color-border);
   background: var(--color-bg-alt);
   box-shadow: var(--shadow-hard-sm);
-  transition: transform 0.1s ease, background 0.1s ease;
+  transition: transform 0.12s ease, background 0.12s ease;
 }
 
 .focus-item::before {
@@ -437,10 +437,14 @@ a.brut-card {
   padding: 0.2rem 0.55rem;
   background: var(--color-surface);
   border: var(--border-w) solid var(--color-border);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
 }
 
 .about-stack-item:hover {
   background: var(--color-accent-soft);
+  transform: translate(-1px, -1px);
+  box-shadow: var(--shadow-hard);
 }
 
 /* ===== Projects ===== */
@@ -457,21 +461,61 @@ a.brut-card {
   }
 }
 
+.project-list.other-work-list {
+  grid-template-columns: 1fr;
+}
+
 .project-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  padding: 0.9rem 1rem;
   border: var(--border-w) solid var(--color-border);
   background: var(--color-surface);
   box-shadow: var(--shadow-hard);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
 .project-row:hover,
 .project-row:focus-within {
   transform: translate(-2px, -2px);
   box-shadow: var(--shadow-hard-lg);
+  background: var(--color-accent-soft);
+}
+
+.project-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.9rem 1rem;
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  height: 100%;
+}
+
+.project-link:hover .project-name,
+.project-link:focus-visible .project-name {
+  color: var(--color-accent);
+}
+
+.project-link:focus-visible {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 2px;
+}
+
+.project-link-arrow {
+  position: absolute;
+  top: 0.7rem;
+  right: 0.85rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-accent);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.project-link:hover .project-link-arrow,
+.project-link:focus-visible .project-link-arrow {
+  opacity: 1;
+  transform: translateX(0);
 }
 
 .project-name {
@@ -528,21 +572,29 @@ a.brut-card {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0.5rem 1rem;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px dashed var(--color-border);
-  background: transparent;
-  transition: background 0.1s ease, padding-left 0.15s ease;
+  padding: 0.6rem 0.85rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard-sm);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-.compact-row:hover {
+.compact-row:hover,
+.compact-row:focus-within {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard-lg);
   background: var(--color-accent-soft);
-  padding-left: 1rem;
+}
+
+.compact-row:hover .compact-name {
+  color: var(--color-accent);
 }
 
 .compact-name {
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--color-ink);
+  transition: color 0.15s ease;
 }
 
 .compact-name::before {
@@ -591,7 +643,7 @@ a.brut-card {
   border: var(--border-w) solid var(--color-border);
   background: var(--color-surface);
   box-shadow: var(--shadow-hard-sm);
-  transition: transform 0.12s ease, background 0.12s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
 .side-project-view-all::before {
@@ -603,19 +655,9 @@ a.brut-card {
 .side-project-view-all:hover,
 .side-project-view-all:focus-visible {
   transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard);
   background: var(--color-accent);
   outline: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .side-project-view-all {
-    transition: background 0.12s ease;
-  }
-
-  .side-project-view-all:hover,
-  .side-project-view-all:focus-visible {
-    transform: none;
-  }
 }
 
 .side-project-list {
@@ -653,6 +695,11 @@ a.brut-card {
   outline: none;
 }
 
+.side-project-row:hover .side-project-name,
+.side-project-row:focus-visible .side-project-name {
+  color: var(--color-accent);
+}
+
 .side-project-info {
   display: flex;
   flex-direction: column;
@@ -665,6 +712,7 @@ a.brut-card {
   font-weight: 700;
   color: var(--color-ink);
   letter-spacing: -0.01em;
+  transition: color 0.15s ease;
 }
 
 .side-project-name::before {
@@ -683,10 +731,11 @@ a.brut-card {
   color: var(--color-accent);
   font-weight: 700;
   flex-shrink: 0;
-  transition: transform 0.2s ease;
+  transition: transform 0.15s ease;
 }
 
-.side-project-row:hover .side-project-arrow {
+.side-project-row:hover .side-project-arrow,
+.side-project-row:focus-visible .side-project-arrow {
   transform: translateX(4px);
 }
 
@@ -709,13 +758,13 @@ a.brut-card {
   box-shadow: var(--shadow-hard-sm);
   text-decoration: none;
   color: inherit;
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
   flex-wrap: wrap;
 }
 
 .writing-row:hover,
 .writing-row:focus-visible {
-  transform: translate(-1px, -1px);
+  transform: translate(-2px, -2px);
   box-shadow: var(--shadow-hard);
   background: var(--color-accent-soft);
   outline: none;
@@ -746,18 +795,25 @@ a.brut-card {
   color: var(--color-ink);
   flex: 1;
   min-width: 0;
+  transition: color 0.15s ease;
+}
+
+.writing-row:hover .writing-title,
+.writing-row:focus-visible .writing-title {
+  color: var(--color-accent);
 }
 
 .writing-arrow {
   font-size: 0.95rem;
   color: var(--color-ink-muted);
-  transition: transform 0.2s ease, color 0.2s ease;
+  transition: transform 0.15s ease, color 0.15s ease;
   margin-left: auto;
   flex-shrink: 0;
 }
 
-.writing-row:hover .writing-arrow {
-  transform: translateX(3px);
+.writing-row:hover .writing-arrow,
+.writing-row:focus-visible .writing-arrow {
+  transform: translateX(4px);
   color: var(--color-accent);
 }
 
@@ -785,7 +841,7 @@ a.brut-card {
   border: var(--border-w) solid var(--color-border);
   background: var(--color-surface);
   box-shadow: var(--shadow-hard-sm);
-  transition: transform 0.12s ease, background 0.12s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
 .writing-view-all::before {
@@ -795,7 +851,8 @@ a.brut-card {
 
 .writing-view-all:hover,
 .writing-view-all:focus-visible {
-  transform: translate(-1px, -1px);
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard);
   background: var(--color-accent-soft);
   outline: none;
 }
@@ -831,7 +888,7 @@ a.brut-card {
   border: var(--border-w) solid var(--color-border);
   background: var(--color-surface);
   box-shadow: var(--shadow-hard);
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, color 0.15s ease;
 }
 
 .contact-link::before {
@@ -938,5 +995,36 @@ a.brut-card {
 
   .hero-scroll-arrow {
     animation: none;
+  }
+
+  .brut-card:hover,
+  .brut-card:focus-visible,
+  .project-row:hover,
+  .project-row:focus-within,
+  .compact-row:hover,
+  .compact-row:focus-within,
+  .side-project-row:hover,
+  .side-project-row:focus-visible,
+  .writing-row:hover,
+  .writing-row:focus-visible,
+  .contact-link:hover,
+  .contact-link:focus-visible,
+  .contact-link.is-highlighted,
+  .side-project-view-all:hover,
+  .side-project-view-all:focus-visible,
+  .writing-view-all:hover,
+  .writing-view-all:focus-visible,
+  .focus-item:hover,
+  .about-stack-item:hover {
+    transform: none;
+  }
+
+  .side-project-row:hover .side-project-arrow,
+  .side-project-row:focus-visible .side-project-arrow,
+  .writing-row:hover .writing-arrow,
+  .writing-row:focus-visible .writing-arrow,
+  .project-link:hover .project-link-arrow,
+  .project-link:focus-visible .project-link-arrow {
+    transform: none;
   }
 }

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -1,0 +1,146 @@
+.project-page .post-title {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.project-tagline {
+  margin: 0.75rem 0 1.25rem;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--color-ink-soft);
+  max-width: 65ch;
+}
+
+.project-tagline::before {
+  content: '// ';
+  color: var(--color-ink-muted);
+}
+
+.project-facts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem 1.5rem;
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.1rem;
+  border: var(--border-w) solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-hard);
+}
+
+@media (min-width: 640px) {
+  .project-facts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .project-fact--wide {
+    grid-column: 1 / -1;
+  }
+
+  .project-fact--role {
+    grid-column: span 2;
+  }
+}
+
+.project-fact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+}
+
+.project-fact dt {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+}
+
+.project-fact dt::before {
+  content: '$ ';
+  color: var(--color-accent);
+}
+
+.project-fact dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-ink);
+  line-height: 1.45;
+}
+
+.project-fact--role dd {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.project-role-headline {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  letter-spacing: 0.01em;
+  line-height: 1.3;
+}
+
+.project-role-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1rem;
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.project-role-item {
+  color: var(--color-ink-soft);
+}
+
+.project-role-item::before {
+  content: '> ' / '';
+  color: var(--color-accent);
+  font-weight: 700;
+}
+
+.project-stack {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.project-stack-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-ink);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  letter-spacing: 0.01em;
+}
+
+.project-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.project-links a {
+  font-weight: 600;
+  color: var(--color-accent);
+  text-decoration: none;
+  border-bottom: 1px dashed currentColor;
+}
+
+.project-links a:hover,
+.project-links a:focus-visible {
+  color: var(--color-ink);
+}


### PR DESCRIPTION
## Summary
- Convert featured projects from a hardcoded array in `index.astro` into an Astro content collection; each project now gets its own page at `/projects/<slug>/`.
- Add `projects` schema in `content.config.ts`, six project markdown entries, the `[slug].astro` template, and dedicated `projects.css`.
- Refine hover/focus states across project rows, compact `other-work` rows, side projects, writing rows, and CTA buttons; consolidate reduced-motion overrides.

## Test plan
- [x] `npm run build` — 38 pages built, all six `/projects/<slug>/` routes generated
- [ ] Spot-check a project detail page in preview
- [ ] Verify hover/focus on `/` for project rows, other-work rows, side projects, writing rows
- [ ] Verify reduced-motion behavior