### PR TITLE
feat(seo): Add article meta, project OG covers, and projects index

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "prebuild": "node scripts/generate-blog-og.mjs",
+    "prebuild": "node scripts/generate-blog-og.mjs && node scripts/generate-project-og.mjs",
     "build": "astro build",
     "check": "astro check",
     "preview": "astro preview",
     "generate:og": "node scripts/generate-og.mjs",
     "generate:blog-og": "node scripts/generate-blog-og.mjs",
+    "generate:project-og": "node scripts/generate-project-og.mjs",
     "generate:icons": "node scripts/generate-icons.mjs"
   },
   "dependencies": {

--- a/scripts/generate-blog-og.mjs
+++ b/scripts/generate-blog-og.mjs
@@ -25,11 +25,23 @@ function readFrontmatter(file) {
   const match = src.match(/^---([\s\S]*?)---/);
   if (!match) return {};
   const data = {};
+  let listKey = null;
   for (const line of match[1].split('\n')) {
-    const m = line.match(/^([a-zA-Z]+):\s*(.+)$/);
+    const item = line.match(/^\s+-\s+(.+)$/);
+    if (item && listKey) {
+      data[listKey].push(item[1].trim().replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+    const m = line.match(/^([a-zA-Z]+):\s*(.*)$/);
     if (!m) continue;
     const [, key, raw] = m;
-    data[key] = raw.trim().replace(/^['"]|['"]$/g, '');
+    if (raw.trim() === '') {
+      data[key] = [];
+      listKey = key;
+    } else {
+      data[key] = raw.trim().replace(/^['"]|['"]$/g, '');
+      listKey = null;
+    }
   }
   return data;
 }
@@ -144,7 +156,7 @@ for (const entry of entries) {
   const fm = readFrontmatter(join(BLOG_DIR, entry));
   if (fm.draft === 'true') continue;
   const title = fm.title ?? slug;
-  const tags = parseTags(fm.tags);
+  const tags = Array.isArray(fm.tags) ? fm.tags : parseTags(fm.tags);
   const svg = buildSvg({ title, tags });
   const out = join(OUT_DIR, `${slug}.png`);
   await sharp(Buffer.from(svg)).png({ compressionLevel: 9 }).toFile(out);

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -1,0 +1,153 @@
+import sharp from 'sharp';
+import { readdirSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECTS_DIR = resolve(__dirname, '../src/content/projects');
+const OUT_DIR = resolve(__dirname, '../public/og/projects');
+
+if (!existsSync(OUT_DIR)) {
+  mkdirSync(OUT_DIR, { recursive: true });
+}
+
+function escapeXml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function readFrontmatter(file) {
+  const src = readFileSync(file, 'utf8');
+  const match = src.match(/^---([\s\S]*?)---/);
+  if (!match) return {};
+  const data = {};
+  let listKey = null;
+  for (const line of match[1].split('\n')) {
+    const item = line.match(/^\s+-\s+(.+)$/);
+    if (item && listKey) {
+      data[listKey].push(item[1].trim().replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+    const m = line.match(/^([a-zA-Z]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, raw] = m;
+    if (raw.trim() === '') {
+      data[key] = [];
+      listKey = key;
+    } else {
+      data[key] = raw.trim().replace(/^['"]|['"]$/g, '');
+      listKey = null;
+    }
+  }
+  return data;
+}
+
+function wrapLines(title, maxChars, maxLines) {
+  const words = title.split(/\s+/);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length > maxChars && current) {
+      lines.push(current);
+      current = word;
+      if (lines.length === maxLines - 1) break;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current && lines.length < maxLines) {
+    lines.push(current);
+  }
+  if (lines.length === maxLines && words.join(' ').length > lines.join(' ').length) {
+    const last = lines[lines.length - 1];
+    lines[lines.length - 1] = last.length > maxChars - 1
+      ? `${last.slice(0, maxChars - 1)}…`
+      : `${last}…`;
+  }
+  return lines;
+}
+
+function buildSvg({ slug, title, stack }) {
+  const safeTitle = escapeXml(title);
+  const lines = wrapLines(safeTitle, 26, 3);
+  const titleY = 290;
+  const lineHeight = 78;
+  const chips = stack.slice(0, 4).map((s) => s.toLowerCase());
+
+  const titleTspans = lines
+    .map((line, i) => {
+      const cursor = i === lines.length - 1
+        ? `${line}<tspan fill="#ff6a1a">_</tspan>`
+        : line;
+      return `<tspan x="90" y="${titleY + i * lineHeight}">${cursor}</tspan>`;
+    })
+    .join('');
+
+  let chipX = 90;
+  const chipSvg = chips
+    .map((chip) => {
+      const width = Math.max(80, chip.length * 14 + 30);
+      const block = `
+        <rect x="${chipX}" y="500" width="${width}" height="44" fill="#fdfbf0" stroke="#0a0a0a" stroke-width="2"/>
+        <text x="${chipX + 15}" y="529" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="20" font-weight="600" fill="#0a0a0a">${escapeXml(chip)}</text>`;
+      chipX += width + 14;
+      return block;
+    })
+    .join('');
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#f5f1dc" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="630" fill="#fdfbf0"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <rect x="40" y="40" width="1120" height="550" fill="#fffdf3" stroke="#0a0a0a" stroke-width="3"/>
+  <rect x="46" y="46" width="1120" height="550" fill="none" stroke="#0a0a0a" stroke-width="3" opacity="0.08"/>
+
+  <rect x="40" y="40" width="1120" height="52" fill="#f5f1dc" stroke="#0a0a0a" stroke-width="3"/>
+  <circle cx="72" cy="66" r="7" fill="#ff6a1a"/>
+  <circle cx="96" cy="66" r="7" fill="#0a0a0a" fill-opacity="0.15"/>
+  <circle cx="120" cy="66" r="7" fill="#0a0a0a" fill-opacity="0.15"/>
+  <text x="160" y="73" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="18" font-weight="600" fill="#3a3a3a">ralph@jonas:~/projects/${escapeXml(slug)} — readme.md</text>
+
+  <text x="90" y="180" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="22" fill="#6b6b66">
+    <tspan fill="#ff6a1a" font-weight="700">$</tspan> cat readme.md
+  </text>
+
+  <text font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="64" font-weight="800" fill="#0a0a0a" letter-spacing="-2">
+    ${titleTspans}
+  </text>
+
+  ${chipSvg}
+
+  <line x1="90" y1="585" x2="1110" y2="585" stroke="#0a0a0a" stroke-width="2"/>
+  <text x="90" y="568" font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="20" font-weight="600" fill="#0a0a0a">ralphjonas.com/projects</text>
+</svg>
+`;
+}
+
+const entries = readdirSync(PROJECTS_DIR).filter((f) => f.endsWith('.md'));
+let count = 0;
+for (const entry of entries) {
+  const slug = entry.replace(/\.md$/, '');
+  const fm = readFrontmatter(join(PROJECTS_DIR, entry));
+  if (fm.draft === 'true') continue;
+  const title = fm.title ?? slug;
+  const stack = Array.isArray(fm.stack) ? fm.stack : [];
+  const svg = buildSvg({ slug, title, stack });
+  const out = join(OUT_DIR, `${slug}.png`);
+  await sharp(Buffer.from(svg)).png({ compressionLevel: 9 }).toFile(out);
+  count += 1;
+}
+
+console.log(`generated ${count} project OG images → ${OUT_DIR}`);

--- a/src/content/projects/ai-dev-workflow-standards.md
+++ b/src/content/projects/ai-dev-workflow-standards.md
@@ -1,7 +1,7 @@
 ---
 name: ai-dev-workflow-standards
 title: AI-Assisted Developer Workflow Standards
-description: Internal standards for AI-assisted development — agent setup, prompt patterns, repo conventions, and review gates that make Claude- and OpenAI-driven coding consistent and reviewable across a team.
+description: Internal standards for AI-assisted development — agent setup, prompt patterns, and review gates that keep Claude and OpenAI coding consistent across a team.
 summary: An opinionated playbook for using AI coding agents on a real codebase — how agents are configured, what they're allowed to do unattended, what they're not, and how their output gets reviewed before it lands. Built around Claude and OpenAI tooling.
 stack:
   - Claude (Anthropic)

--- a/src/content/projects/ai-meeting-editor.md
+++ b/src/content/projects/ai-meeting-editor.md
@@ -1,7 +1,7 @@
 ---
 name: ai-meeting-editor
 title: AI Meeting Editor — Auto-Trim Dead Air
-description: AI-powered meeting editor that detects the real start and end of a discussion and trims dead air using Whisper, Deepgram, FFmpeg, and PyTorch on AWS — transcripts plus voice-activity heuristics, not just silence detection.
+description: AI meeting editor that detects where a discussion really starts and ends, trimming dead air with Whisper, Deepgram, FFmpeg, and PyTorch on AWS.
 summary: A media pipeline that takes raw meeting recordings and returns clean cuts with the small talk, setup chatter, and dead air removed. Combines ASR (Whisper / Deepgram), voice-activity detection, and lightweight semantic boundary models to find where the conversation actually starts and ends.
 stack:
   - Python

--- a/src/content/projects/airline-data-bots.md
+++ b/src/content/projects/airline-data-bots.md
@@ -1,7 +1,7 @@
 ---
 name: airline-data-bots
 title: Airline Data Bots — Scheduled Availability Scrapers
-description: Automated scrapers that collect flight availability data from multiple airline sources on schedule — TypeScript and Puppeteer for the headless browser layer, BullMQ for distributed job scheduling and retries.
+description: Scheduled scrapers collecting flight availability from multiple airline sources — TypeScript and Puppeteer with BullMQ job scheduling and retries.
 summary: A fleet of scheduled scrapers that pull flight availability from multiple airline sources, normalize the results, and publish them into the search platform. Built around a Puppeteer pool, a BullMQ-backed queue, and retry/backoff policies that survive the messy realities of public airline endpoints.
 stack:
   - TypeScript

--- a/src/content/projects/billing-payment-platform.md
+++ b/src/content/projects/billing-payment-platform.md
@@ -1,7 +1,7 @@
 ---
 name: billing-payment-platform
 title: Multi-Gateway Billing & Payment Platform
-description: Payment orchestration across multiple gateways with unified subscription billing, dunning, and smart retry logic — built in TypeScript on an event-driven GCP stack.
+description: Payment orchestration across multiple gateways with unified subscription billing, dunning, and smart retries — TypeScript on an event-driven GCP stack.
 summary: A unified subscription billing layer that abstracts multiple payment gateways behind a single domain model. Handles charges, refunds, retries, dunning, and lifecycle events without leaking gateway-specific quirks into product code.
 stack:
   - Node.js

--- a/src/content/projects/flight-rewards-search.md
+++ b/src/content/projects/flight-rewards-search.md
@@ -1,7 +1,7 @@
 ---
 name: flight-rewards-search
 title: Flight Rewards Search Engine
-description: Reward flight availability search across major airlines — Node.js + TypeScript backend, PostgreSQL search index, and GCP-hosted ingestion pipelines that keep award seat data fresh at scale.
+description: Reward flight availability search across major airlines — Node.js and TypeScript backend, PostgreSQL search index, and GCP ingestion pipelines.
 summary: Technical lead on a UK-based SaaS that searches reward flight availability across major airline programs. Backend, data ingestion, and search infrastructure built on Node.js, TypeScript, PostgreSQL, and Google Cloud Platform.
 stack:
   - Node.js

--- a/src/content/projects/subscription-event-bus.md
+++ b/src/content/projects/subscription-event-bus.md
@@ -1,7 +1,7 @@
 ---
 name: subscription-event-bus
 title: Subscription Event Bus on GCP Pub/Sub
-description: Event-driven subscription billing on Google Cloud Pub/Sub — async lifecycle fan-out, idempotent consumers, retry policies, and dead-letter handling that keep billing reliable under load.
+description: Event-driven subscription billing on GCP Pub/Sub — lifecycle fan-out, idempotent consumers, retry policies, and dead-letter handling under load.
 summary: The event backbone behind subscription billing — a Pub/Sub-based bus that fans subscription lifecycle changes out to billing, notifications, analytics, and ops consumers. Designed for at-least-once delivery, idempotent processing, and clean recovery from upstream failures.
 stack:
   - Node.js

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,6 +21,8 @@ const {
   breadcrumb,
   suppressDefaultBreadcrumb = false,
   dateModified,
+  datePublished,
+  articleTags = [],
   noindex = false
 } = Astro.props;
 
@@ -177,6 +179,19 @@ const resolvedBreadcrumb = breadcrumb ?? (suppressDefaultBreadcrumb ? null : def
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+
+    {ogType === 'article' && datePublished && (
+      <meta property="article:published_time" content={datePublished} />
+    )}
+    {ogType === 'article' && dateModified && (
+      <meta property="article:modified_time" content={dateModified} />
+    )}
+    {ogType === 'article' && (
+      <meta property="article:author" content={SITE_URL} />
+    )}
+    {ogType === 'article' && articleTags.map((tag: string) => (
+      <meta property="article:tag" content={tag} />
+    ))}
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@ralphsenpaidev" />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="404 | ralph jonas mungcal" noindex={true}>
+<BaseLayout title="404 — Page Not Found — Ralph Jonas Mungcal" noindex={true}>
   <main class="not-found">
     <div class="not-found__inner">
       <div class="not-found__shell" aria-hidden="true">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -75,6 +75,8 @@ const breadcrumb = {
   ogImage={ogImage}
   ogImageAlt={ogImageAlt}
   dateModified={dateModified}
+  datePublished={post.data.pubDate.toISOString()}
+  articleTags={post.data.tags}
   breadcrumb={breadcrumb}
 >
   <Fragment slot="head">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -261,6 +261,10 @@ const sideProjectItemList = {
             <span class="compact-tech">rpi · python · mongo · express · angular</span>
           </li>
         </ul>
+
+        <a href="/projects/" class="writing-view-all motion-fade">
+          view all projects <span aria-hidden="true">&rarr;</span>
+        </a>
       </div>
     </section>
 

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -59,7 +59,8 @@ const breadcrumb = {
   '@type': 'BreadcrumbList',
   itemListElement: [
     { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
-    { '@type': 'ListItem', position: 2, name: project.data.title, item: canonicalURL }
+    { '@type': 'ListItem', position: 2, name: 'Projects', item: 'https://ralphjonas.com/projects/' },
+    { '@type': 'ListItem', position: 3, name: project.data.title, item: canonicalURL }
   ]
 };
 ---
@@ -93,7 +94,7 @@ const breadcrumb = {
       <span>ralph@jonas:~/projects/{project.id} — readme.md</span>
     </div>
 
-    <a href="/#projects" class="post-back" aria-label="Back to projects">
+    <a href="/projects/" class="post-back" aria-label="Back to projects">
       <span class="post-back-arrow" aria-hidden="true">&larr;</span>
       <span class="post-back-label">all projects</span>
     </a>
@@ -170,7 +171,7 @@ const breadcrumb = {
     </article>
 
     <nav class="post-nav" aria-label="Project navigation">
-      <a href="/#projects" class="post-nav-link">&larr; all projects</a>
+      <a href="/projects/" class="post-nav-link">&larr; all projects</a>
       <a href="/" class="post-nav-link">$ cd ~/</a>
     </nav>
   </main>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -73,6 +73,7 @@ const breadcrumb = {
   ogImage={ogImage}
   ogImageAlt={ogImageAlt}
   dateModified={dateModified}
+  articleTags={keywords}
   breadcrumb={breadcrumb}
 >
   <Fragment slot="head">

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -28,7 +28,7 @@ const canonicalURL = project.data.canonical
   ?? `https://ralphjonas.com/projects/${project.id}/`;
 
 const dateModified = project.data.updatedDate?.toISOString();
-const ogImage = 'https://ralphjonas.com/og.png';
+const ogImage = `https://ralphjonas.com/og/projects/${project.id}.png`;
 const ogImageAlt = `${project.data.title} — project by Ralph Jonas Mungcal`;
 
 const keywords = [

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -59,8 +59,7 @@ const breadcrumb = {
   '@type': 'BreadcrumbList',
   itemListElement: [
     { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
-    { '@type': 'ListItem', position: 2, name: 'Projects', item: 'https://ralphjonas.com/#projects' },
-    { '@type': 'ListItem', position: 3, name: project.data.title, item: canonicalURL }
+    { '@type': 'ListItem', position: 2, name: project.data.title, item: canonicalURL }
   ]
 };
 ---

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,156 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import '../../styles/blog.css';
+
+const projects = (await getCollection('projects', ({ data }) => !data.draft))
+  .sort((a, b) => a.data.order - b.data.order);
+
+const title = 'Projects — Ralph Jonas Mungcal';
+const description =
+  'Selected projects by Ralph Jonas Mungcal — payment platforms, flight search engines, AI media pipelines, and developer tooling.';
+const canonicalURL = 'https://ralphjonas.com/projects/';
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://ralphjonas.com/' },
+    { '@type': 'ListItem', position: 2, name: 'Projects', item: canonicalURL }
+  ]
+};
+
+const collectionPage = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  '@id': `${canonicalURL}#collectionpage`,
+  url: canonicalURL,
+  name: title,
+  description,
+  inLanguage: 'en',
+  isPartOf: { '@id': 'https://ralphjonas.com/#website' },
+  hasPart: projects.map((project) => ({
+    '@type': 'SoftwareSourceCode',
+    '@id': `https://ralphjonas.com/projects/${project.id}/#project`,
+    name: project.data.title,
+    url: `https://ralphjonas.com/projects/${project.id}/`,
+    description: project.data.description
+  }))
+};
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  canonicalURL={canonicalURL}
+  breadcrumb={breadcrumb}
+>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(collectionPage)}></script>
+  </Fragment>
+
+  <main class="blog-page">
+    <h1 class="visually-hidden">Projects by Ralph Jonas Mungcal</h1>
+
+    <div class="blog-shell-bar" role="banner">
+      <div class="blog-shell-bar-dots" aria-hidden="true">
+        <span class="blog-shell-bar-dot blog-shell-bar-dot--live"></span>
+        <span class="blog-shell-bar-dot"></span>
+        <span class="blog-shell-bar-dot"></span>
+      </div>
+      <span>ralph@jonas:~/projects — ls</span>
+    </div>
+
+    <div class="blog-header">
+      <span class="blog-header-prompt">$</span>
+      <span class="blog-header-cmd">ls ./projects/</span>
+      <span class="blog-header-flag">--sort=order</span>
+    </div>
+    <hr class="blog-rule" role="presentation" />
+
+    <p class="blog-intro">
+      the work i'm proudest of — payments, search, scrapers, and ai pipelines. each one has a write-up.
+    </p>
+
+    <ul class="project-index-list" role="list">
+      {projects.map((project) => (
+        <li class="project-index-item">
+          <a href={`/projects/${project.id}/`} class="project-index-link" aria-label={`Open project: ${project.data.name}`}>
+            <span class="project-index-name">{project.data.name}</span>
+            <span class="project-index-tech">
+              {project.data.tech ?? project.data.stack.map((s) => s.toLowerCase()).join(' · ')}
+            </span>
+            <p class="project-index-desc">{project.data.description.toLowerCase()}</p>
+            <span class="project-index-arrow" aria-hidden="true">&rarr;</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+
+    <div class="post-nav">
+      <a href="/" class="post-nav-link">$ cd ~/</a>
+      <a href="/now/" class="post-nav-link">/now &rarr;</a>
+    </div>
+  </main>
+
+  <style>
+    .project-index-list {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 2.5rem;
+      display: grid;
+      gap: 0.9rem;
+    }
+
+    .project-index-link {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-template-areas:
+        'name arrow'
+        'tech arrow'
+        'desc arrow';
+      gap: 0.25rem 1rem;
+      align-items: center;
+      padding: 1rem 1.1rem;
+      text-decoration: none;
+      color: var(--color-ink);
+      border: var(--border-w) solid var(--color-border);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-hard-sm);
+      transition: transform 0.12s ease, box-shadow 0.12s ease;
+    }
+
+    .project-index-link:hover,
+    .project-index-link:focus-visible {
+      transform: translate(-2px, -2px);
+      box-shadow: var(--shadow-hard-lg);
+      outline: none;
+    }
+
+    .project-index-name {
+      grid-area: name;
+      font-weight: 700;
+      font-size: 1.05rem;
+    }
+
+    .project-index-tech {
+      grid-area: tech;
+      font-size: 0.78rem;
+      color: var(--color-ink-muted);
+    }
+
+    .project-index-desc {
+      grid-area: desc;
+      margin: 0.2rem 0 0;
+      font-size: 0.85rem;
+      color: var(--color-ink-soft);
+      line-height: 1.5;
+    }
+
+    .project-index-arrow {
+      grid-area: arrow;
+      color: var(--color-accent);
+      font-weight: 700;
+    }
+  </style>
+</BaseLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,6 +16,8 @@ export async function GET(context: APIContext) {
       link: `/blog/${post.id}/`,
       categories: post.data.tags
     })),
-    customData: '<language>en</language>'
+    xmlns: { atom: 'http://www.w3.org/2005/Atom' },
+    customData:
+      '<language>en</language><atom:link href="https://ralphjonas.com/rss.xml" rel="self" type="application/rss+xml"/>'
   });
 }


### PR DESCRIPTION
## What

SEO pass over every page, plus the follow-ups that came out of the audit.

**Meta fixes**
- emit `article:published_time` / `modified_time` / `author` / `tag` OG meta on blog posts and project pages (og:type was article but none of these existed)
- trim all six project meta descriptions under 160 chars, they were 164-222 and got truncated in search results
- add `atom:link rel=self` to the RSS feed
- 404 title now matches the site title format

**Projects hub**
- new `/projects/` index page with CollectionPage schema. project breadcrumbs pointed at the `/#projects` fragment, which Google strips, so position 2 duplicated Home. breadcrumbs, back links, and a new homepage link now point at the real page
- per-project OG covers generated in prebuild, same terminal design as blog covers. project pages stop sharing the generic og.png

**Bug found along the way**
- the blog OG script never parsed YAML block-list tags, so tag chips were missing from every blog cover. fixed the parser

## Testing

- `npm run build` passes, 39 pages
- verified built HTML: article meta present, breadcrumb JSON-LD three levels with real URLs, per-project og:image, /projects/ in sitemap
- eyeballed regenerated blog and project covers

🤖 Generated with [Claude Code](https://claude.com/claude-code)