### PR TITLE
feat(contact): Replace Upwork link with Bluesky

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -52,7 +52,7 @@ const person = {
   ],
   sameAs: [
     'https://www.linkedin.com/in/ralphjonasmungcal',
-    'https://www.upwork.com/o/profiles/users/_~01108375a06953763f/',
+    'https://bsky.app/profile/ralphdev.bsky.social',
     'https://ralphdev.bearblog.dev/',
     'https://x.com/ralphsenpaidev'
   ]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -374,7 +374,7 @@ const sideProjectItemList = {
           <a href="mailto:ralphmungcal09@gmail.com" class="contact-link motion-stagger">email</a>
           <a href="https://www.linkedin.com/in/ralphjonasmungcal" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">linkedin</a>
           <a href="https://x.com/ralphsenpaidev" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">x</a>
-          <a href="https://www.upwork.com/o/profiles/users/_~01108375a06953763f/" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">upwork</a>
+          <a href="https://bsky.app/profile/ralphdev.bsky.social" class="contact-link motion-stagger" target="_blank" rel="noopener noreferrer">bluesky</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replace the Upwork profile link with a Bluesky profile (`bsky.app/profile/ralphdev.bsky.social`)
- Update both the visible contact link on the home page and the `sameAs` structured-data array in `BaseLayout.astro`

## Changes
- `src/pages/index.astro` — contact list link `upwork` → `bluesky`
- `src/layouts/BaseLayout.astro` — Person schema `sameAs` URL updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)