### PR TITLE
perf: Fix font-swap CLS and drop unused PostHog modules

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -222,6 +222,11 @@ const resolvedBreadcrumb = breadcrumb ?? (suppressDefaultBreadcrumb ? null : def
             autocapture: false,
             capture_pageview: true,
             capture_pageleave: true,
+            // Skip modules we don't use so PostHog stops loading their
+            // extra bundles (surveys.js, dead-clicks, web-vitals).
+            disable_surveys: true,
+            capture_dead_clicks: false,
+            capture_performance: false,
           });
         };
         // Defer init (which loads array.js) off the critical render path.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,17 @@
+/* Metric-matched fallback so the swap to JetBrains Mono doesn't shift layout.
+   JetBrains Mono is 600/1000 advance (same as generic monospace, so widths
+   already match); only its vertical metrics (ascent 1020 / descent 300) differ.
+   Overriding the fallback's metrics to match keeps line boxes stable on swap. */
+@font-face {
+  font-family: 'JetBrains Mono Fallback';
+  src: local('Menlo'), local('Consolas'), local('DejaVu Sans Mono'),
+    local('Liberation Mono'), local('Courier New');
+  size-adjust: 100%;
+  ascent-override: 102%;
+  descent-override: 30%;
+  line-gap-override: 0%;
+}
+
 /* ===== Design Tokens — Terminal Brutalism ===== */
 :root {
   --color-bg: #fdfbf0;
@@ -17,7 +31,7 @@
 
   --border-w: 2px;
 
-  --font-mono: 'JetBrains Mono', 'IBM Plex Mono', 'Geist Mono', ui-monospace,
+  --font-mono: 'JetBrains Mono', 'JetBrains Mono Fallback', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
 


### PR DESCRIPTION
Second pass on the Lighthouse findings after the font-subsetting PR (#73).

## CLS — 0.256 → expected < 0.1
The LCP element is the oversized hero heading. It painted in system monospace, then **shifted when JetBrains Mono swapped in**. JetBrains Mono's advance width is 600/1000 — identical to generic monospace — so widths already matched; only the vertical metrics (ascent 1020 / descent 300) differed, changing line-box heights on swap.

Fix: a metric-matched `JetBrains Mono Fallback` `@font-face` (overrides measured from the woff2 with `@capsizecss/unpack`) inserted into the `--font-mono` stack. Line boxes stay stable through the swap. Network-independent — no preload needed.

```css
@font-face {
  font-family: 'JetBrains Mono Fallback';
  src: local('Menlo'), local('Consolas'), local('DejaVu Sans Mono'), ...;
  size-adjust: 100%;        /* widths already match */
  ascent-override: 102%;    /* 1020/1000 */
  descent-override: 30%;    /* 300/1000 */
  line-gap-override: 0%;
}
```

## Unused / legacy JS — 61 KiB unused + 17 KiB legacy
PostHog was pulling `surveys.js` (32 KiB), `dead-clicks-autocapture.js` (6 KiB), and `web-vitals.js` (3 KiB) for features the site doesn't use. Disabled via `disable_surveys`, `capture_dead_clicks`, `capture_performance` — those bundles and their requests are no longer fetched, which also trims the third-party cache-lifetime bytes.

## Verification
- `npm run build` passes (41 pages); built with a dummy key to confirm the PostHog options compile
- Confirmed the fallback `@font-face` + updated `--font-mono` are inlined into the built HTML

## Not fixable in code (noted for follow-up)
- **Cache lifetimes (158 KiB):** the `/_astro/*` assets are content-hashed and immutable but Cloudflare serves them with a 4h edge TTL. Needs a Cloudflare cache rule (`/_astro/*` → Edge TTL 1 year) in the dashboard. PostHog's own 4h TTL is third-party.
- **Remaining legacy JS (~8 KiB):** PostHog core `array.js` — can't recompile a third-party bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CE1KvhxGoeAzBX9s65LNm9