### PR TITLE
fix(hero): Reserve subtitle box so typewriter doesn't shift layout

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -123,8 +123,12 @@ const sideProjectItemList = {
         </h1>
 
         <p class="hero-subtitle motion-fade" data-typewriter={HERO_SUBTITLE}>
-          <span class="hero-subtitle-text">{HERO_SUBTITLE}</span>
-          <span class="hero-cursor" aria-hidden="true"></span>
+          <span class="hero-subtitle-sizer" aria-hidden="true">{HERO_SUBTITLE}</span>
+          <span class="hero-subtitle-typed" aria-hidden="true">
+            <span class="hero-subtitle-text">{HERO_SUBTITLE}</span>
+            <span class="hero-cursor"></span>
+          </span>
+          <span class="visually-hidden">{HERO_SUBTITLE}</span>
         </p>
 
         <div class="hero-tags motion-fade" aria-hidden="true">

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -195,6 +195,20 @@
   max-width: 52ch;
   line-height: 1.6;
   min-height: 3.2em;
+  position: relative;
+}
+
+/* Invisible copy of the full subtitle reserves the final box size so the
+   typewriter never reflows the layout as it types (prevents hero CLS). */
+.hero-subtitle-sizer {
+  visibility: hidden;
+}
+
+/* The animated text is overlaid on the sizer and taken out of flow, so
+   filling it in character by character can't change the box height. */
+.hero-subtitle-typed {
+  position: absolute;
+  inset: 0;
 }
 
 .hero-subtitle-text {


### PR DESCRIPTION
The hero CLS (~0.19, the dominant chunk of the 0.25 total) was the **typewriter**, not the font swap — the size-adjust fallback in #74 barely moved it.

As the subtitle types out, the text wraps onto a third line and grows the box, pushing the tags + scroll cue down and expanding `hero-inner`. The `min-height: 3.2em` only reserved two lines.

## Fix
- An invisible `hero-subtitle-sizer` holds the full text and reserves the final box footprint from first paint.
- The animated text moves into `hero-subtitle-typed`, an absolutely-positioned overlay (`inset: 0`) — so filling it character by character can no longer change the box height.
- The full subtitle is exposed once to assistive tech via a `visually-hidden` copy; the animating nodes are `aria-hidden`.

No JS change needed — the typewriter still targets `.hero-subtitle-text` and the cursor rides inside the overlay.

## Verification
- `npm run build` passes (41 pages)
- Confirmed sizer + overlay markup and `position:absolute;inset:0` / `visibility:hidden` rules in the built HTML

Expected result: the subtitle (and `hero-inner`) no longer shift during typing → CLS should drop from ~0.25 toward the box-stable floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CE1KvhxGoeAzBX9s65LNm9