### PR TITLE
feat(projects): Animate project list rows on load

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -73,8 +73,8 @@ const collectionPage = {
     </p>
 
     <ul class="project-index-list" role="list">
-      {projects.map((project) => (
-        <li class="project-index-item">
+      {projects.map((project, i) => (
+        <li class="project-index-item" style={`--row: ${i};`}>
           <a href={`/projects/${project.id}/`} class="project-index-link" aria-label={`Open project: ${project.data.name}`}>
             <span class="project-index-name">{project.data.name}</span>
             <span class="project-index-tech">
@@ -100,6 +100,24 @@ const collectionPage = {
       margin: 0 0 2.5rem;
       display: grid;
       gap: 0.9rem;
+    }
+
+    /* Terminal "ls" output: rows print in one after another on load. */
+    .project-index-item {
+      opacity: 0;
+      animation: project-row-in 0.32s ease both;
+      animation-delay: calc(var(--row, 0) * 70ms);
+    }
+
+    @keyframes project-row-in {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
 
     .project-index-link {
@@ -151,6 +169,33 @@ const collectionPage = {
       grid-area: arrow;
       color: var(--color-accent);
       font-weight: 700;
+      transition: transform 0.12s ease;
+    }
+
+    .project-index-link:hover .project-index-arrow,
+    .project-index-link:focus-visible .project-index-arrow {
+      transform: translateX(4px);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .project-index-item {
+        opacity: 1;
+        animation: none;
+      }
+
+      .project-index-arrow {
+        transition: none;
+      }
+
+      .project-index-link:hover,
+      .project-index-link:focus-visible {
+        transform: none;
+      }
+
+      .project-index-link:hover .project-index-arrow,
+      .project-index-link:focus-visible .project-index-arrow {
+        transform: none;
+      }
     }
   </style>
 </BaseLayout>


### PR DESCRIPTION
## What

Project index rows now fade up in sequence on page load — like terminal `ls` output printing line by line. The reveal is staggered with a per-row `--row` index custom property feeding `animation-delay`. The row arrow also nudges right on hover/focus for affordance.

## Notes

- Both effects respect `prefers-reduced-motion: reduce` (rows render immediately, arrow stays put).
- Animated properties are `opacity`/`transform` only, so the reveal runs on the compositor.
- Reviewed with `/simplify`: arrow-hover styling overlaps the existing `.blog-list-arrow` pattern in `blog.css`; left as-is rather than extracting a shared class, which would touch blog/now pages outside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)