### PR TITLE
style(projects): Ease row load-in out for natural settle

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -105,7 +105,7 @@ const collectionPage = {
     /* Terminal "ls" output: rows print in one after another on load. */
     .project-index-item {
       opacity: 0;
-      animation: project-row-in 0.32s ease both;
+      animation: project-row-in 0.32s ease-out both;
       animation-delay: calc(var(--row, 0) * 70ms);
     }
 


### PR DESCRIPTION
## What

The project-list row entrance reveal used the default `ease` (ease-in-out), which ramps in slowly before settling. Switched to `ease-out` so rows decelerate into place — the correct easing category for an entrance and a cleaner read for a fade-up.

## Notes

- Stays a standard keyword to match the codebase's keyword-based easing (no exotic cubic-bezier).
- Only entrance animation on the page, so no consistency conflict with the site's hover transitions.
- Build passes (41 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)